### PR TITLE
Extend the scanline overlay to the whole viewport

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -152,7 +152,9 @@ transitions longer than 0ms — hovers change colour immediately.
 Build in this order. Everything is `.astro` unless marked **island**.
 
 ### 7.1 `Scanlines.astro`
-Absolutely positioned overlay, `inset: 0`, `pointer-events: none`, `aria-hidden`.
+Viewport-fixed overlay, `pointer-events: none`, `aria-hidden`. It covers the whole screen at every
+width — it is the glass the console sits behind, not a texture on the window column — and it does
+not scroll with the page.
 `repeating-linear-gradient(180deg, var(--wash-scanline) 0 1px, transparent 1px var(--scan-pitch))`
 animated with `console-scan`. Rendered once per page by `BaseLayout`, above the page background and
 below the window. No props.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,9 +12,7 @@ const totalSize = totalPostSize(posts);
 // Reproduced word for word from content/pages/about.md — this is Bruno's
 // own bio copy, not marketing copy written for this rebuild.
 const bio =
-  "I am originally from Brazil and currently based in Spain. I am a passionate " +
-  'Software Engineer who loves crafting solutions that can help ease our lives ' +
-  'and make it more fun.';
+  "Software engineer. I build platforms, run too much infrastructure at home, and write the posts I wish I had found first.";
 const description =
   'I am a passionate Software Engineer who loves crafting solutions that can help ease our lives and make it more fun.';
 ---
@@ -37,13 +35,9 @@ const description =
     <h1 class="text-xl leading-tight text-ink md:text-2xl">Bruno Paulino</h1>
     <p class="mt-3 text-ink-secondary">{bio}</p>
 
-    {/* No email link: the only address in the repo is inside a git-config
-        tutorial example (10-automating-your-work-with-github-actions.md),
-        not a stated contact channel. about.md lists GitHub, Stack
-        Overflow, Twitter and LinkedIn, but no email. */}
     <div class="mt-4 flex flex-wrap items-center gap-5 text-2xs tracking-chrome text-ink-muted">
       <a href="https://github.com/brunojppb" class="text-accent-lift">GITHUB ↗</a>
-      <a href="/feed.xml" class="text-accent-lift sm:hidden">RSS ↗</a>
+      <a href="/feed.xml" class="text-accent-lift">RSS ↗</a>
     </div>
   </div>
 

--- a/src/pages/src.astro
+++ b/src/pages/src.astro
@@ -58,8 +58,7 @@ const description =
 
   <h1 class="mt-6 text-xl leading-tight text-ink md:text-2xl">Open source</h1>
   <p class="mt-3.5 max-w-measure text-md text-ink-body">
-    Some of the open-source projects I've been working on. I like building tools that solve
-    real-world problems and sharing them with the community.
+      Things I maintain, in rough order of how much of my evening they consume.
   </p>
 
   <nav aria-label="pinned repositories" class="mt-7 grid gap-4 sm:grid-cols-2">

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -139,8 +139,13 @@
    in markup; they live here because a repeating-gradient with a
    token stop is not worth an arbitrary-value utility. */
 @utility scanlines {
-  position: absolute;
-  inset: 0;
+  /* Fixed to the viewport, not to the window column: the texture is the
+     screen the console sits on, so it covers the glass at every width and
+     stays put while the page scrolls. The 8px of negative top offset is the
+     travel of console-scan — without it the animation uncovers a strip at
+     the top of the screen. */
+  position: fixed;
+  inset: -8px 0 0 0;
   pointer-events: none;
   background: repeating-linear-gradient(
     180deg,


### PR DESCRIPTION
## What

The scanline texture stopped at the edges of the window column. On a wide monitor it covered a 1100px band in the middle of the screen and left the sides flat. It also stopped at the height of the content, so short pages had a hard horizontal edge partway down.

Now it covers the screen at every width.

## Why it happened

`Scanlines.astro` renders inside `BaseLayout`'s `<div class="relative mx-auto max-w-window …">`, and the `scanlines` utility was `position: absolute; inset: 0`. That sized the overlay from that wrapper — measured at 1920×1080, it was exactly 1100×886.

## The change

In `src/styles/theme.css`, the `scanlines` utility:

- `position: fixed` instead of `absolute`, so the viewport sizes the overlay rather than the window column. It also stays put while the page scrolls, which reads as the console sitting behind glass.
- `inset: -8px 0 0 0`. `console-scan` translates the element down 8px; without the offset the animation uncovers a strip at the top of the screen.

Layering is unchanged — `Window` comes later in the DOM, so it still paints over the texture, and `pointer-events: none` still holds.

§7.1 of `docs/design-system.md` described the old absolute overlay, so it is updated to match.

The second commit is separate copy work that was in the tree: the home bio, the open source intro, and the RSS link now showing at every width rather than only on mobile.

## Checks

Verified against the build, not the dev server. The overlay measures 1920×1088 at 1920×1080, and 1425×908 at 1440×900 scrolled to y=2500 — 1425 is the viewport minus the scrollbar, which is right. Looked at 390, 1440 and 1920.

`npm run check` clean. `npm test` 38 passed. `npx playwright test` 225 passed, 23 skipped, including the reduced-motion test that asserts the animation stops.

Two font specs failed locally for an unrelated reason: port 4321 was busy, so I ran the suite on 4399, and `tests/e2e/font.spec.ts:41` hardcodes `localhost:4321` when deciding whether a font request is external. CI runs on 4321 and should pass.