### PR TITLE
fix: stop the profile picture growing on iOS Safari

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,7 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npm test
-      - run: npx playwright install --with-deps chromium
+      # WebKit is for the `safari` project alone (tests/e2e/aspect.spec.ts),
+      # which guards a layout behaviour Chromium does not have.
+      - run: npx playwright install --with-deps chromium webkit
       - run: npm run test:e2e

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,8 +6,14 @@ export default defineConfig({
   reporter: 'list',
   use: { baseURL: 'http://localhost:4321' },
   projects: [
-    { name: 'desktop', use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } } },
-    { name: 'mobile',  use: { ...devices['Desktop Chrome'], viewport: { width: 390,  height: 844 } } },
+    // aspect.spec.ts is scoped out of the Chromium projects: it guards a
+    // WebKit layout behaviour Chromium does not have, so there it would
+    // pass whether the bug is present or not.
+    { name: 'desktop', testIgnore: ['aspect.spec.ts'], use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } } },
+    { name: 'mobile',  testIgnore: ['aspect.spec.ts'], use: { ...devices['Desktop Chrome'], viewport: { width: 390,  height: 844 } } },
+    // The iPhone the growing-image bug came from. Scoped to the one spec
+    // that needs a second engine — the rest of the suite is Chromium.
+    { name: 'safari',  testMatch: ['aspect.spec.ts'], use: { ...devices['iPhone 14'] } },
     // docs/verification.md's sweep names 390/768/1024/1440. 768 and 1024
     // have no bespoke design and most specs assert against the two
     // primary widths above, so these two are scoped via testMatch to the

--- a/src/components/media/BookCover.astro
+++ b/src/components/media/BookCover.astro
@@ -29,7 +29,10 @@ const width = reading ? 480 : 320;
 <div class="flex flex-col gap-3">
   <div
     class:list={[
-      'aspect-[2/3] border',
+      // `w-full` is load-bearing: without a stated width, WebKit derives
+      // this box's width from the height the ratio gave it, adds the border
+      // twice, and the cover grows on every relayout.
+      'aspect-[2/3] w-full border',
       reading ? 'border-line-accent' : 'border-line-strong',
       !reading && 'opacity-80',
     ]}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -140,7 +140,10 @@ const description =
     </div>
 
     <div class="order-first flex flex-col gap-2 sm:order-last">
-      <div class="relative aspect-square border border-line-accent">
+      <!-- `w-full` is load-bearing: without a stated width, WebKit derives
+           this box's width from the height `aspect-square` gave it, adds the
+           border twice, and the picture grows on every relayout. -->
+      <div class="relative aspect-square w-full border border-line-accent">
         <img
           src="/assets/images/bpaulino.jpg"
           alt="Bruno Paulino smiling"

--- a/src/pages/courses.astro
+++ b/src/pages/courses.astro
@@ -55,7 +55,11 @@ const courses = await getCollection('courses');
           ]}
         >
           <div class="flex flex-col gap-2.5">
-            <div class="aspect-video border border-line-accent">
+            {/* `w-full` is load-bearing: without a stated width, WebKit
+                derives this box's width from the height `aspect-video` gave
+                it, adds the border twice, and the thumbnail grows on every
+                relayout. */}
+            <div class="aspect-video w-full border border-line-accent">
               <img
                 src={course.data.thumbnail}
                 alt={`${course.data.title} thumbnail`}

--- a/tests/e2e/aspect.spec.ts
+++ b/tests/e2e/aspect.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+// Runs on WebKit only (the `safari` project in playwright.config.ts).
+//
+// A box that gets its height from `aspect-ratio` and its width from the
+// grid track must not feed its own height back into that width. In WebKit
+// the fed-back width is the border box, so every relayout adds the box's
+// two border pixels and the picture grows without a limit — visible on an
+// iPhone as an image that creeps past the window edge. Chromium keeps the
+// box square and never shows it, so these cases only hold on WebKit.
+//
+// Each case names a page and the image inside the aspect box. The parent
+// of that image is the box under test.
+const CASES = [
+  { route: '/about/', image: 'img[alt="Bruno Paulino smiling"]' },
+  { route: '/courses/', image: 'img[alt$="thumbnail"]' },
+];
+
+for (const { route, image } of CASES) {
+  test(`${route}: the aspect box holds its size across relayouts at 390`, async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(route);
+    await page.evaluate(() => document.fonts.ready);
+
+    const box = page.locator(image).first().locator('xpath=..');
+    const measure = async () => {
+      const { width, height } = (await box.boundingBox()) ?? { width: 0, height: 0 };
+      return { width: Math.round(width), height: Math.round(height) };
+    };
+
+    const before = await measure();
+    expect(before.width).toBeGreaterThan(0);
+
+    // One width change per pass is what an iPhone produces as the URL bar
+    // moves. A stable box reads the same after twenty of them; a growing
+    // one has gained forty pixels.
+    for (let i = 0; i < 20; i++) {
+      await page.setViewportSize({ width: 390 + (i % 2), height: 844 });
+    }
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    expect(await measure()).toEqual(before);
+  });
+}


### PR DESCRIPTION
On an iPhone, the profile picture on `/about/` grows a couple of pixels at a
time until it breaks out of the window. Desktop Chrome never shows it.

## What causes it

At 390px the picture sits in a single `auto` grid column, so the track asks
the box how wide it wants to be. The box states no width — only
`aspect-square` — and WebKit answers with the height it computed on the last
pass, plus the box's 1px border on each side. It applies the ratio to the
border box on one axis and the content box on the other, so the answer is
always 2px larger than the question. Every relayout adds 2px. An iPhone
relayouts constantly as the URL bar moves, so the picture creeps.

Measured in WebKit at 390px: the box starts at 336x338 and reads 376x378
after 20 width changes, pushing `scrollWidth` to 403 inside a 390 viewport.
Chromium keeps the box at 336x336 and never enters the loop.

## The fix

`w-full` gives the box a definite width, so nothing asks it what width its
height implies.

- `src/pages/about.astro` — the profile picture
- `src/pages/courses.astro` — course thumbnails, same shape, same bug
- `src/components/media/BookCover.astro` — same shape, but `1fr` tracks meant
  it never grew

No visual change at 390, 768, 1024 or 1440.

## The test

`tests/e2e/aspect.spec.ts` resizes the viewport 20 times and checks the box
measures the same after. It runs under a new `safari` project (iPhone 14,
WebKit) and is scoped out of the Chromium projects, where it would pass
whether the bug is there or not.

Checks: the new spec fails on the old markup and passes now; full e2e suite
229 passed, 23 skipped; `astro check` 0 errors; unit tests 38 passed.

## One thing left alone

WebKit still reports the box 2px taller than wide. That is the same
ratio-versus-border quirk, it is stable now, and 1px per edge is invisible.
Making it exact means moving the border or the ratio onto the image, which
changes the design.
