### PR TITLE
Rewrite the about page intro and tighten the /src copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,19 @@
-# CLAUDE.md — bpaulino.com
+# CLAUDE.md, bpaulino.com
 
-Personal blog. Astro, static, Tailwind v4, Cloudflare Pages. The visual language is **CONSOLE** —
+Personal blog. Astro, static, Tailwind v4, Cloudflare Pages. The visual language is **CONSOLE**:
 a dark, monospaced, terminal-shaped design system. The full spec is in `docs/design-system.md`;
 the values are in `src/styles/theme.css`.
 
 ## Standing rules
 
-**The design is decided.** Reproduce it; do not improve it. If something is missing, ask — do not
+**The design is decided.** Reproduce it; do not improve it. If something is missing, ask. Do not
 improvise in a different visual language.
 
 **One font, one weight.** Departure Mono, 400. No `font-bold`, no `<strong>` styled heavier, no
 second typeface. Emphasis is `text-accent-lift`, an inverted fill, a leading `█`, or uppercase with
 `tracking-label`.
 
-**Type sizes are multiples of 11 or 5.5** — the pixel grid the face is drawn on. Use the `text-*`
+**Type sizes are multiples of 11 or 5.5**, the pixel grid the face is drawn on. Use the `text-*`
 tokens. Never 14, 18 or 24px.
 
 **Radius 0, no shadows.** Depth is a 1px border. Both Tailwind scales are deleted on purpose.
@@ -36,7 +36,7 @@ third island needs a reason.
 
 **Body copy is 16.5px at every width.** The frame shrinks on mobile; the text does not.
 
-**Motion is two ambient animations** — the scanline overlay and the caret — and both stop under
+**Motion is two ambient animations**, the scanline overlay and the caret, and both stop under
 `prefers-reduced-motion: reduce`. No page transitions, no scroll animation, no hover transitions.
 
 **Dark only.** There is no theme toggle. The old site had one; this one does not.
@@ -45,8 +45,13 @@ third island needs a reason.
 
 First person, plain, specific. Sentence case for prose; lowercase for anything imitating shell
 output; uppercase only for 11px labels. Counts are always shown. No emoji, no exclamation marks,
-no marketing voice. The user's own copy — course descriptions, post text — is reproduced verbatim
+no marketing voice. The user's own copy (course descriptions, post text) is reproduced verbatim
 and never rewritten or shortened.
+
+**Never use an em dash.** Not in page copy, not in code comments, not in commit messages, PR
+descriptions, docs, or chat. This holds for everything written for this project, with no
+exceptions. Use a full stop, a comma, a colon, or brackets instead. The character is `—`; search
+for it before you commit.
 
 ## Working
 
@@ -56,5 +61,5 @@ npm run build && npx serve dist -p 4321   # verify against the build, not the de
 astro check
 ```
 
-Verify visually at all four test viewports — 390, 768, 1024, 1440 — with Playwright before calling
+Verify visually at all four test viewports (390, 768, 1024, 1440) with Playwright before calling
 any page done. The full check list is in `docs/verification.md`.

--- a/src/data/projects.lock.json
+++ b/src/data/projects.lock.json
@@ -5,6 +5,12 @@
     "license": "MIT",
     "description": "Blazingly fast Turborepo remote cache server written in Rust as a Github Action with Docker support for Linux and MacOS"
   },
+  "brunojppb/rush-cache-server": {
+    "stars": 2,
+    "language": "Rust",
+    "license": "MIT",
+    "description": "Rush distributed caching server for your CI builds"
+  },
   "brunojppb/sanitisium": {
     "stars": 5,
     "language": "Rust",

--- a/src/data/projects.yaml
+++ b/src/data/projects.yaml
@@ -3,32 +3,28 @@
 # with Bruno's own prose (paragraphs, below); everything else renders as a
 # row in the compact list, using the GitHub API's own description field.
 #
-# curso-react-para-iniciantes and rails_contact_list are excluded on purpose
-# — Bruno's two highest-starred repos, but both are course companion repos
-# that belong with /courses/, not here. brunojppb.github.io (this site) and
-# markitdown-ui (named in the old page's meta description but not among his
-# public non-fork repos) are excluded too.
+# The two cache servers are pinned. Everything else is a row, sanitisium
+# included.
+#
+# curso-react-para-iniciantes and rails_contact_list are excluded on purpose.
+# They are Bruno's two highest-starred repos, but both are course companion
+# repos that belong with /courses/, not here. brunojppb.github.io (this site)
+# and markitdown-ui (named in the old page's meta description but not among
+# his public non-fork repos) are excluded too.
 - slug: brunojppb/turbo-cache-server
   pinned: true
   paragraphs:
-    - A blazingly fast Turborepo remote cache server written in Rust. This self-hosted solution
-      accelerates monorepo build processes by caching and reusing build artifacts, dramatically
-      reducing build times in CI/CD pipelines.
-    - The server is compatible with S3-compatible storage services like AWS S3, Cloudflare R2, and
-      Minio, making it flexible for different deployment scenarios. It can be deployed as a GitHub
-      Action or Docker container, supporting various CI environments including GitHub and GitLab.
+    - A Turborepo remote cache in Rust. Self-hosted, works with any S3-compatible store, and runs
+      as a GitHub Action or a Docker container.
 
-- slug: brunojppb/sanitisium
+- slug: brunojppb/rush-cache-server
   pinned: true
   paragraphs:
-    - "A secure PDF sanitization service written in Rust that eliminates threats by completely
-      regenerating documents. Instead of trying to parse and remove threats, Sanitisium takes a
-      unique approach: it converts PDF pages into 300 DPI bitmaps and creates entirely new PDFs
-      from those images."
-    - This method removes all potential security threats including malicious JavaScript, exploit
-      payloads, phishing links, and buffer overflow risks. The project includes a CLI tool, core
-      library, and HTTP API with background job processing, all built with process isolation for
-      maximum security and performance.
+    - A build cache for Rush monorepos, also in Rust. It sits between Rush and a private S3
+      bucket, so the bucket never has to be public.
+
+- slug: brunojppb/sanitisium
+  pinned: false
 
 - slug: brunojppb/node-distributed-lock
   pinned: false

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,11 +2,11 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import PromptLine from '../components/shell/PromptLine.astro';
 
-// Every string on this page is reproduced word for word from
-// content/pages/about.md — Bruno's own bio and role history, not copy
-// written for this rebuild. Only punctuation that isn't in Departure Mono
-// (the "•" bullet in each role's meta line) was swapped for the allowed
-// "·" middot; no word was added, removed or reordered.
+// The intro is new copy, written with Bruno. The role history below is
+// reproduced word for word from content/pages/about.md. Only punctuation
+// that isn't in Departure Mono (the "•" bullet in each role's meta line)
+// was swapped for the allowed "·" middot; no word was added, removed or
+// reordered in those.
 
 interface Segment {
   text: string;
@@ -87,12 +87,11 @@ const roles: Role[] = [
   },
 ];
 
-// The stack sentence from about.md: "I have been writing web applications
-// using Scala, Elixir, JavaScript and TypeScript."
-const STACK = ['Scala', 'Elixir', 'JavaScript', 'TypeScript'];
+// Matches the closing line of the intro.
+const STACK = ['Scala', 'Elixir', 'JavaScript', 'TypeScript', 'Rust'];
 
 const description =
-  'I am a passionate Software Engineer who loves crafting solutions that can help ease our lives and make it more fun.';
+  'Brazilian software engineer based in Spain. I build open source tools in my spare time, and some of them run at Cursor, SpaceX, BBC, N26 and Buffer.';
 ---
 
 <BaseLayout
@@ -111,14 +110,22 @@ const description =
   <div class="mt-6 grid gap-9 sm:grid-cols-[1fr_200px] sm:items-start">
     <div>
       <h1 class="text-xl leading-tight text-ink md:text-2xl">Bruno Paulino</h1>
-      <p class="mt-3.5 max-w-measure text-md text-ink-body">Hi There, Bruno Paulino here.</p>
+      <p class="mt-3.5 max-w-measure text-md text-ink-body">Hi there, Bruno Paulino here.</p>
       <p class="mt-3.5 max-w-measure text-md text-ink-body">
-        I am originally from Brazil and currently based in Spain. I am a passionate Software
-        Engineer who loves crafting solutions that can help ease our lives and make it more fun.
+        Brazilian, living in Spain, writing web software for long enough to have opinions about
+        build times.
       </p>
       <p class="mt-3.5 max-w-measure text-md text-ink-body">
-        I am mainly interested in Web development and programming languages these days. I have
-        been writing web applications using Scala, Elixir, JavaScript and TypeScript.
+        I also enjoy building open source tools in my spare time. Some of them now run at{' '}
+        <a href="/src/" class="text-accent-lift">Cursor, SpaceX, BBC, N26 and Buffer</a>. Somewhere
+        a rocket company waits a little less for a build.
+      </p>
+      <p class="mt-3.5 max-w-measure text-md text-ink-body">
+        Along the way I've worked in banking, e-commerce and aviation. Internet banking, bikes for
+        kids, and private jets. I still commute by bike.
+      </p>
+      <p class="mt-3.5 max-w-measure text-md text-ink-body">
+        Scala, Elixir, TypeScript, and Rust when the problem earns it.
       </p>
       <nav aria-label="profiles" class="mt-3 flex flex-wrap gap-1 text-2xs tracking-chrome">
         <a href="https://github.com/brunojppb" class="flex min-h-11 items-center pr-3.5 text-accent-lift">

--- a/src/pages/src.astro
+++ b/src/pages/src.astro
@@ -7,8 +7,8 @@ import SectionRule from '../components/shell/SectionRule.astro';
 import Tag from '../components/listing/Tag.astro';
 import { getRepoStats, type RepoStats } from '../lib/github';
 
-// Repos shown here are a judgment call, not derived from any API query —
-// see src/data/projects.yaml for the list and why curso-react-para-iniciantes,
+// Repos shown here are a judgment call, not derived from any API query.
+// See src/data/projects.yaml for the list and why curso-react-para-iniciantes,
 // rails_contact_list, brunojppb.github.io and markitdown-ui are excluded.
 interface ProjectEntry {
   slug: string;
@@ -40,7 +40,7 @@ const repoUrl = (slug: string) => `https://github.com/${slug}`;
 const repoName = (slug: string) => slug.split('/')[1];
 
 const description =
-  "Open-source projects I maintain, from a Rust build cache server to a handful of smaller tools.";
+  "Open-source projects I maintain, from two Rust build cache servers to a handful of smaller tools.";
 ---
 
 <BaseLayout

--- a/tests/e2e/listing.spec.ts
+++ b/tests/e2e/listing.spec.ts
@@ -1,4 +1,13 @@
+import { readFileSync } from 'node:fs';
 import { test, expect } from '@playwright/test';
+import { parse } from 'yaml';
+
+// The compact list on /src/ is whatever projects.yaml does not pin, so the
+// count comes from the same file the page builds from. Hard-coding it means
+// every repo added or pinned breaks this test for no real reason.
+const COMPACT_REPO_COUNT = (
+  parse(readFileSync('src/data/projects.yaml', 'utf-8')) as { pinned: boolean }[]
+).filter((p) => !p.pinned).length;
 
 test('the home page shows between three and five posts', async ({ page }) => {
   await page.goto('/');
@@ -57,6 +66,8 @@ test('/src/ compact repo rows are at least 44px tall at 390', async ({ page }, t
   );
   // Asserted first, and exact, so a selector typo (matching zero rows)
   // fails loudly here instead of passing the height loop vacuously.
-  expect(heights.length).toBe(4);
+  // Guards the guard: a count of zero would make the line below vacuous too.
+  expect(COMPACT_REPO_COUNT).toBeGreaterThan(0);
+  expect(heights.length).toBe(COMPACT_REPO_COUNT);
   for (const h of heights) expect(h).toBeGreaterThanOrEqual(44);
 });


### PR DESCRIPTION
Two copy changes on one branch.

## About page intro

The intro described me in generic terms and said nothing about the work. It now leads with the open source tools, names the companies running them, and covers the industries I have worked in.

Before:

> I am originally from Brazil and currently based in Spain. I am a passionate Software Engineer who loves crafting solutions that can help ease our lives and make it more fun.
>
> I am mainly interested in Web development and programming languages these days. I have been writing web applications using Scala, Elixir, JavaScript and TypeScript.

After:

> Brazilian, living in Spain, writing web software for long enough to have opinions about build times.
>
> I also enjoy building open source tools in my spare time. Some of them now run at Cursor, SpaceX, BBC, N26 and Buffer. Somewhere a rocket company waits a little less for a build.
>
> Along the way I've worked in banking, e-commerce and aviation. Internet banking, bikes for kids, and private jets. I still commute by bike.
>
> Scala, Elixir, TypeScript, and Rust when the problem earns it.

The role history below the intro is untouched. The company list is the page's one accent, in `text-accent-lift`, linking to `/src/`. Rust joins the `$STACK` chips. The meta description matches the new copy.

## Open source page

Both pinned cards carried two paragraphs of marketing prose. Each is one short paragraph now. The turbo card goes from 75 words to 24, and "blazingly fast", "dramatically reducing" and "maximum security" are gone, which the no-marketing-voice rule ruled out anyway.

> **turbo-cache-server**
> A Turborepo remote cache in Rust. Self-hosted, works with any S3-compatible store, and runs as a GitHub Action or a Docker container.

> **rush-cache-server**
> A build cache for Rush monorepos, also in Rust. It sits between Rush and a private S3 bucket, so the bucket never has to be public.

`rush-cache-server` takes the second pinned card. `sanitisium` moves to the compact list, where it keeps its GitHub description. Its lock entry is written by hand so the committed file is right without a DEV refresh.

## CLAUDE.md

New rule: never use an em dash in anything written for this project. The six already in that file are gone.

## Checks

`astro check` reports 0 errors. The build passes, 52 pages. I checked `/about/` and `/src/` against the build at 390, 768, 1024 and 1440. The two pinned cards stay side by side and level at every width.

## Known gap

Page titles still read `About — bpaulino.com`, and more em dashes remain across `src/`. That sweep is not in this PR.