### PR TITLE
feat: highlight the outline entry for the section being read

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -278,10 +278,15 @@ Props: `src` (optional), `alt`, `status` (`reading` | `finished`).
 Grid: 4-up desktop / 2-up mobile for reading; 6-up desktop / 3-up mobile for finished.
 
 ### 7.13 `Outline.astro`
-Props: `headings` (`{depth, text, slug}[]`), `activeSlug`.
+Props: `headings` (`{depth, text, slug}[]`), `variant` (`rail` | `disclosure`).
 Desktop: sticky rail, 11px `OUTLINE` label, entries rendered with their markdown prefix — `## The
 problem` — active entry in `--text-accent`.
 Mobile: a bordered disclosure under the post title, collapsed by default.
+The active entry is the section the reader is in, not a build-time prop: a hoisted script marks it
+with `aria-current="location"` as the page scrolls. A heading becomes current once it passes a line
+a quarter down the viewport, so the highlight follows the text on screen. Nothing is marked above
+the first heading; the end of the page belongs to the last one. Colour only, no marker glyph and no
+transition.
 
 ### 7.14 `Pagination.astro`
 Props: `shown`, `total`, `nextHref`.

--- a/src/components/content/Outline.astro
+++ b/src/components/content/Outline.astro
@@ -8,8 +8,11 @@
  * Two anatomies, one component: `rail` is the sticky desktop column, called
  * from the outline aside; `disclosure` is the bordered `<details>` under the
  * title on narrow screens. The route places each at the DOM position its
- * layout needs and lets CSS show only the one that matches the width —
- * there is no scroll-spy, so neither variant carries an active state.
+ * layout needs and lets CSS show only the one that matches the width.
+ *
+ * The entry for the section the reader is in carries `aria-current="location"`,
+ * set by the script below. Both variants read it, so the disclosure highlights
+ * too while it is open.
  */
 interface Heading {
   depth: number;
@@ -34,7 +37,11 @@ const entries = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
         {entries.map((h) => (
           <a
             href={`#${h.slug}`}
-            class:list={['text-xs text-ink-secondary', h.depth === 3 && 'pl-3']}
+            data-outline-link
+            class:list={[
+              'text-xs text-ink-secondary aria-[current=location]:text-accent-lift',
+              h.depth === 3 && 'pl-3',
+            ]}
           >
             {'#'.repeat(h.depth)} {h.text}
           </a>
@@ -55,7 +62,11 @@ const entries = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
         {entries.map((h) => (
           <a
             href={`#${h.slug}`}
-            class:list={['text-xs text-ink-secondary', h.depth === 3 && 'pl-3']}
+            data-outline-link
+            class:list={[
+              'text-xs text-ink-secondary aria-[current=location]:text-accent-lift',
+              h.depth === 3 && 'pl-3',
+            ]}
           >
             {'#'.repeat(h.depth)} {h.text}
           </a>
@@ -64,3 +75,61 @@ const entries = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
     </details>
   )
 }
+
+<script>
+  // Marks the outline entry for the section the reader is in. Astro hoists and
+  // bundles this once per page, so both variants share the one listener.
+  const headings = [
+    ...document.querySelectorAll<HTMLElement>('[data-prose] :is(h2, h3)[id]'),
+  ];
+  const links = new Map<string, HTMLAnchorElement[]>();
+
+  for (const link of document.querySelectorAll<HTMLAnchorElement>('[data-outline-link]')) {
+    const slug = decodeURIComponent((link.getAttribute('href') ?? '').slice(1));
+    if (!slug) continue;
+    const group = links.get(slug);
+    if (group) group.push(link);
+    else links.set(slug, [link]);
+  }
+
+  if (headings.length > 0 && links.size > 0) {
+    let active: string | null = null;
+    let frame = 0;
+
+    const sync = () => {
+      frame = 0;
+
+      // The line sits a quarter down the viewport, so the entry tracks the
+      // section that owns the text the reader is looking at rather than the
+      // heading that happens to be on screen.
+      const line = window.innerHeight * 0.25;
+      let next: string | null = null;
+
+      for (const heading of headings) {
+        if (heading.getBoundingClientRect().top > line) break;
+        next = heading.id;
+      }
+
+      // A short last section never reaches the line, so the end of the page
+      // belongs to the last heading.
+      const bottom = window.scrollY + window.innerHeight;
+      if (bottom >= document.documentElement.scrollHeight - 2) {
+        next = headings[headings.length - 1].id;
+      }
+
+      if (next === active) return;
+
+      for (const link of links.get(active ?? '') ?? []) link.removeAttribute('aria-current');
+      for (const link of links.get(next ?? '') ?? []) link.setAttribute('aria-current', 'location');
+      active = next;
+    };
+
+    const schedule = () => {
+      if (frame === 0) frame = requestAnimationFrame(sync);
+    };
+
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule, { passive: true });
+    sync();
+  }
+</script>


### PR DESCRIPTION
The outline rail lists a post's headings but never says where you are. This
marks the entry for the section you are reading, so the outline doubles as a
progress indicator.

Section 7.13 of `docs/design-system.md` already asked for this ("active entry
in `--text-accent`"). It was never built, and `Outline.astro` said so in a
comment.

## What it does

A hoisted script in `Outline.astro` reads the post's `h2` and `h3` ids and, on
scroll or resize (throttled with `requestAnimationFrame`), sets
`aria-current="location"` on the matching entry.

- A heading becomes current once it passes a line a quarter down the viewport.
  That is what makes "the text in the window belongs to this section" true,
  rather than "the heading is visible".
- Nothing is marked while you are above the first heading. The reader is not in
  a listed section yet, and the first highlight arriving is itself a signal.
- The end of the page belongs to the last heading, otherwise a short final
  section never reaches the line.
- Both anatomies read the attribute, so the mobile disclosure highlights too
  while it is open.

The active entry is `text-accent-lift`, the accent as text, which is the colour
the `h2` in the body already uses. Inactive entries stay `text-ink-secondary`.
Colour only: no marker glyph, no transition, so the motion rule holds.

No new island. The script is about 500 bytes and Astro inlines it.

The spec named an `activeSlug` prop. That cannot exist, since the active section
is a client-side fact, so the §7.13 entry now lists the real props and the
scroll rule.

## Verification

`astro check`: 0 errors. Then against the build (`npm run build` and
`npx serve dist -p 4321`), with Playwright:

- 1440: sweeping down the page tracked The big picture, Step 1, Step 3 and
  Where to go from here in order; the last entry holds at the page bottom.
- 390 with the disclosure open: active `rgb(194,173,250)` (`--color-accent-lift`),
  inactive `rgb(163,160,176)` (`--color-ink-secondary`), no horizontal overflow.
- 768 and 1024: highlight correct, nothing overlaps or overflows.
- A post with nested `h3` entries highlights the `h3` itself.
- A post with no headings (`taming-ambiguity`): the script no-ops, 0 console
  errors. The only warnings on any page are the pre-existing font preload ones.
- Clicking an outline entry lands on that section and highlights it.
