### PR TITLE
fix: lift code comment colour to clear 4.5:1

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -95,7 +95,8 @@ Minimum contrast: no text below 4.5:1 against its own surface. Measured against
 `--surface-window` (#101017): `--text-primary` 14.8:1, `--text-body` 11.3:1, `--text-secondary`
 7.4:1, `--text-muted` 5.4:1. `--text-muted` at 11px is the floor; do not invent anything fainter
 for text. `--text-faint` is
-permitted only inside code blocks where it labels comments, never for UI copy.
+permitted only inside code blocks where it labels comments, never for UI copy. It is measured
+against `--surface-code` instead, where it reaches 4.8:1.
 
 ---
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -81,7 +81,9 @@ document.documentElement.scrollWidth <= document.documentElement.clientWidth
 ```
 
 **4. Contrast.** Every text/surface pair ≥ 4.5:1. Against `--color-surface-window` the design's inks
-compute to 14.8 / 11.3 / 7.4 / 5.4. `--color-ink-faint` is permitted only inside code blocks.
+compute to 14.8 / 11.3 / 7.4 / 5.4. `--color-ink-faint` is permitted only inside code blocks, and it
+carries the least headroom of any pair in the system: 4.8:1 against `--color-surface-code`. Measure it
+on that surface, not on the window, and treat any change to either value as a contrast change.
 
 **5. Tap targets at 390.** Every link inside a listing row ≥ 44px tall.
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -30,7 +30,7 @@
   --color-ink-body:        #c9c6d4;  /* text-ink-body  — prose                      */
   --color-ink-secondary:   #a3a0b0;  /* prompts                                     */
   --color-ink-muted:       #8b8799;  /* 11px labels, dates, counts                  */
-  --color-ink-faint:       #767386;  /* code comments ONLY                          */
+  --color-ink-faint:       #7e7b8e;  /* code comments ONLY; 4.78:1 on surface-code  */
 
   --color-accent:          #a98bf5;  /* fills: bg-accent + text-on-accent           */
   --color-accent-lift:     #c2adfa;  /* accent used as text: text-accent-lift       */


### PR DESCRIPTION
Lighthouse flagged the site for contrast. Every failing element in the report was the same thing: a code comment.

## The cause

Comments render in `--astro-code-token-comment`, which resolves to `--color-ink-faint` (`#767386`). Against `--color-surface-code` (`#0b0b10`) that computes **4.27:1**. Code blocks are 15px at weight 400, so AA needs 4.5:1. It missed by a hair, on every code block on the site.

Nothing else failed. Measured across every ink and accent:

| token | on code bg | on page bg |
|---|---|---|
| ink `#e4e2ea` | 15.30 | 15.11 |
| ink-body `#c9c6d4` | 11.70 | 11.55 |
| ink-secondary `#a3a0b0` | 7.68 | 7.58 |
| ink-muted `#8b8799` | 5.63 | 5.56 |
| **ink-faint `#767386`** | **4.27** | **4.22** |
| accent `#a98bf5` | 7.20 | 7.11 |
| accent-lift `#c2adfa` | 9.96 | 9.83 |
| accent-deep `#7d78d6` | 5.17 | 5.10 |

## The change

One token: `--color-ink-faint` goes from `#767386` to `#7e7b8e`, which now computes **4.78:1**.

The two colours are the same hue and the same chroma. I converted the original to OKLab and raised only lightness, by about 2.5%, so this is the existing purple-grey turned up rather than a new colour. The difference is 8 RGB steps and reads as no design change at all.

`ink-faint` is used for code comments and nothing else, so no other surface moves. The ink ramp still steps down cleanly: comments stay dimmer than the line numbers, which stay dimmer than the body.

I picked `#7e7b8e` over the minimum that clears AA (`#7a778a`, 4.52) so the value survives rounding instead of sitting on the threshold, where any later tweak to the code background would push it back under.

## Docs

`docs/verification.md` and `docs/design-system.md` both stated a 4.5:1 floor and then exempted `ink-faint` to code blocks without ever giving its number, which is how it drifted under the line unnoticed. Both now record 4.8:1 and name the surface it is measured on. That matters here: `ink-faint` only clears AA because code blocks sit on the darkest surface in the system. On `--color-surface-chrome` the same value computes 4.34 and would fail.

## Verification

- `astro check`: 0 errors, 0 warnings. Build passes.
- Measured on the built page, not the dev server: comments compute 4.78:1. All 19 code blocks on the flagged post resolve to that one pair, so every element in the report is covered.
- Swept all 52 built routes with a script that walks every text-rendering element, resolves its real background by climbing the DOM, and applies the correct AA threshold for its font size. No pair fails.
- Checked at 390, 768, 1024 and 1440.
