### PR TITLE
test: run axe over every template, and fix what it found

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -89,6 +89,13 @@ Nine surfaces and inks, one accent. Names and values live in `tokens.css`.
 - **Lines** are the workhorse. Four weights of hairline separate everything; borders do the job
   that shadows and radii do elsewhere.
 
+**Links in body copy are underlined.** A 1px rule at `--border-accent-soft`, 2px below the text,
+going solid accent on hover. This holds in a post and in page copy alike, so the rule lives in
+theme.css's base layer rather than in `Prose.astro`. Colour cannot carry a link on its own here:
+the accent is 1.17:1 against the prose it interrupts, and no colour fixes that, since reaching the
+3:1 WCAG asks for would need a lightness above white or one dark enough to fail 4.5:1 against the
+page. Chrome, nav, the tab strip and listing rows are not body copy and carry no underline.
+
 **Radii are zero everywhere. Shadows do not exist.** The only depth cue is the 1px window border.
 
 Minimum contrast: no text below 4.5:1 against its own surface. Measured against
@@ -308,9 +315,9 @@ and the 404 art collapses into JetBrains Mono.
 
 ### 7.16 `Prose.astro`
 Wraps rendered markdown. Caps at `--measure`. Styles `h2` as `--text-lg --text-accent` prefixed with
-`##`, `p` as `--text-body` with `--space-5` between, `a` as `--text-accent` with a 1px underline that
-becomes solid accent on hover, `ul/ol` with `–` and `01.` markers, `blockquote` with a left 2px
-accent rule.
+`##`, `p` as `--text-body` with `--space-5` between, `ul/ol` with `–` and `01.` markers,
+`blockquote` with a left 2px accent rule. Links are `--text-accent` with a 1px underline that becomes
+solid accent on hover, but that rule is not in this component: see §3.
 
 Sets `--font-prose` on the wrapper, then puts `h2/h3/h4` back to `--font-mono`. That pairing is the
 whole reading experience: console-voice headings with their `##` prefixes over JetBrains Mono

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -85,6 +85,12 @@ compute to 14.8 / 11.3 / 7.4 / 5.4. `--color-ink-faint` is permitted only inside
 carries the least headroom of any pair in the system: 4.8:1 against `--color-surface-code`. Measure it
 on that surface, not on the window, and treat any change to either value as a contrast change.
 
+`tests/e2e/axe.spec.ts` runs this check, and the rest of WCAG 2.1 A/AA, over every template at 1440
+and 390. It uses the axe engine, which is what Lighthouse scores accessibility with, so a green run
+here is the same answer Lighthouse gives. Note what it cannot judge: axe returns "incomplete", not a
+pass, for text over a gradient, which covers the `COVER 2:3` labels on the dither placeholders on
+`/reading/`. Those need an eye. Roughly 1.4% of text nodes land in that bucket; the rest are decided.
+
 **5. Tap targets at 390.** Every link inside a listing row ≥ 44px tall.
 
 **6. Reduced motion.** With `prefers-reduced-motion: reduce`, the scanline overlay must be static and

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "0.9.10",
+        "@axe-core/playwright": "4.13.0",
         "@playwright/test": "1.62.1",
         "@types/hast": "^3.0.5",
         "@types/react": "19.2.18",
@@ -427,6 +428,19 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1438,7 +1452,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1461,7 +1474,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1481,7 +1493,6 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
       "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1504,7 +1515,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1521,7 +1531,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1538,7 +1547,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1555,7 +1563,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1572,7 +1579,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1589,7 +1595,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1606,7 +1611,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1623,7 +1627,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1640,7 +1643,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1657,7 +1659,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1674,7 +1675,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1697,7 +1697,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1720,7 +1719,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1743,7 +1741,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1766,7 +1763,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1789,7 +1785,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1812,7 +1807,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1835,7 +1829,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1855,7 +1848,6 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
       "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1875,7 +1867,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -1895,7 +1886,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1915,7 +1905,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1935,7 +1924,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3648,6 +3636,16 @@
         "@astrojs/markdown-remark": {
           "optional": true
         }
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.10",
+    "@axe-core/playwright": "4.13.0",
     "@playwright/test": "1.62.1",
     "@types/hast": "^3.0.5",
     "@types/react": "19.2.18",

--- a/src/components/content/CodeBlock.astro
+++ b/src/components/content/CodeBlock.astro
@@ -29,7 +29,7 @@ const lines = code.replace(/\n$/, '').split('\n');
     <span class={c.label}>{label}</span>
     <CopyButton client:visible text={code} />
   </figcaption>
-  <pre class={c.pre}><code>{lines.map((line, i) => (
+  <pre class={c.pre} tabindex="0"><code>{lines.map((line, i) => (
     <div class={c.line}>
       {showLineNumbers && <span class={c.lineNumber}>{i + 1}</span>}
       <span>{line === '' ? '\u00A0' : line}</span>

--- a/src/components/content/Prose.astro
+++ b/src/components/content/Prose.astro
@@ -78,16 +78,8 @@
     content: '#### ';
   }
 
-  .prose :global(a) {
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 2px;
-    text-decoration-color: var(--color-line-accent);
-  }
-
-  .prose :global(a):hover {
-    text-decoration-color: var(--color-accent-lift);
-  }
+  /* Link underlines are not here. They cover page copy outside this component
+     too, so the one rule lives in theme.css's base layer. */
 
   .prose :global(ul),
   .prose :global(ol) {

--- a/src/lib/code-block-classes.ts
+++ b/src/lib/code-block-classes.ts
@@ -15,6 +15,9 @@ export const codeBlockClasses = {
   header: 'flex items-center justify-between border-b border-line-hairline bg-surface-chrome px-4 py-2 font-mono',
   label: 'text-2xs uppercase tracking-chrome text-ink-muted',
   copyButton: 'text-2xs uppercase tracking-chrome text-ink-muted hover:text-accent-lift',
+  // The body scrolls sideways, so it needs `tabindex="0"` to be reachable by
+  // keyboard. Shiki already emits it on a fenced block; `CodeBlock.astro` sets
+  // it by hand so both paths behave the same.
   pre: 'overflow-x-auto bg-surface-code p-4 text-sm text-ink-body',
   line: 'flex whitespace-pre',
   lineNumber: 'mr-4 inline-block w-10 shrink-0 select-none text-right text-ink-muted',

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -165,6 +165,23 @@
   a { color: var(--color-accent-lift); text-decoration: none }
   a:hover { color: var(--color-ink) }
 
+  /* A link sitting in body copy carries an underline. Against the prose it
+     interrupts, the accent is 1.17:1, so colour alone cannot tell the two
+     apart, and no colour can: reaching 3:1 against `--color-ink-body` needs
+     either a luminance above white or one dark enough to fail the 4.5:1 floor
+     against the page. Chrome, nav, the tab strip and listing rows are not body
+     copy and stay clean. */
+  .prose a,
+  p a {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    text-decoration-color: var(--color-line-accent);
+  }
+
+  .prose a:hover,
+  p a:hover { text-decoration-color: var(--color-accent-lift) }
+
   :focus-visible {
     outline: 2px solid var(--color-accent);
     outline-offset: 2px;

--- a/tests/e2e/axe.spec.ts
+++ b/tests/e2e/axe.spec.ts
@@ -1,0 +1,79 @@
+import AxeBuilder from '@axe-core/playwright';
+import { test, expect } from '@playwright/test';
+import { ROUTES } from './routes';
+
+/**
+ * Runs the axe engine over every template and fails on any WCAG 2.1 A/AA
+ * violation.
+ *
+ * This is the same engine behind Lighthouse's accessibility score, so a run
+ * here reproduces the report that sent us looking in the first place. It exists
+ * because the code comment colour drifted under 4.5:1 and nothing in the suite
+ * noticed: `tests/unit/contrast.test.ts` checks the `contrastRatio` function
+ * against hex literals typed into the test, so editing a token cannot fail it,
+ * and `a11y.spec.ts` never looked at colour at all.
+ *
+ * This runs in the `desktop` and `mobile` projects only, because `tablet` and
+ * `laptop` name their files with `testMatch` and do not name this one. The
+ * rules here are about colour and semantics rather than layout, so the two
+ * intermediate widths would only repeat the same findings.
+ */
+
+const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+/**
+ * Violations that are real, understood, and waiting on a decision rather than
+ * on a fix. Listing a rule here still reports it: the test below prints what
+ * each exception is currently suppressing, so an entry cannot rot into silence.
+ * Empty is the goal, and it is currently empty.
+ */
+const KNOWN: Record<string, string> = {};
+
+for (const route of ROUTES) {
+  test(`axe reports no WCAG A/AA violations: ${route}`, async ({ page }) => {
+    await page.goto(route);
+    // Contrast is measured against rendered glyphs, so the webfont has to have
+    // landed. Without this the first routes race the font swap.
+    await page.evaluate(() => document.fonts.ready);
+
+    const { violations } = await new AxeBuilder({ page }).withTags(TAGS).analyze();
+
+    const [known, unexpected] = [
+      violations.filter((v) => v.id in KNOWN),
+      violations.filter((v) => !(v.id in KNOWN)),
+    ];
+
+    for (const v of known) {
+      console.log(`  known: ${v.id} x${v.nodes.length} on ${route}: ${KNOWN[v.id]}`);
+    }
+
+    expect(
+      unexpected.map((v) => ({
+        rule: v.id,
+        impact: v.impact,
+        help: v.help,
+        nodes: v.nodes.map((n) => ({ target: n.target, why: n.failureSummary })),
+      }))
+    ).toEqual([]);
+  });
+}
+
+/**
+ * The regression this suite was built for, pinned to the exact pair that broke.
+ * The sweep above would catch it too, but only as one entry in a list of
+ * hundreds of nodes. This one names the colours, so a failure here says which
+ * token moved instead of leaving someone to read a stack of selectors.
+ */
+test('code comments clear 4.5:1 against the code surface', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop', 'a colour check; one project is enough');
+
+  await page.goto('/entries/https-for-your-homelab/');
+  await page.evaluate(() => document.fonts.ready);
+
+  const { violations } = await new AxeBuilder({ page })
+    .include('pre')
+    .withRules(['color-contrast'])
+    .analyze();
+
+  expect(violations.flatMap((v) => v.nodes).map((n) => n.failureSummary)).toEqual([]);
+});


### PR DESCRIPTION
Adds an axe pass over the whole site, then fixes the two real problems it found.

## Why the existing tests could not have caught the contrast bug

`tests/unit/contrast.test.ts` checks the `contrastRatio` function against hex literals typed into the test:

```ts
const WINDOW = '#101017';
expect(contrastRatio('#e4e2ea', WINDOW)).toBeCloseTo(14.8, 0);  // ink
```

It never reads `theme.css`, and it omits `ink-faint` entirely, so editing the token cannot fail it. `a11y.spec.ts` covers heading order, tap targets, `lang` and nav names, but never looked at colour. Contrast had no coverage against real rendered pixels.

## The suite

`tests/e2e/axe.spec.ts` runs the axe engine over every route in `ROUTES`, at 1440 and 390, and fails on any WCAG 2.1 A/AA violation. Axe is the engine behind Lighthouse's accessibility score, so a green run here is the same answer Lighthouse gives.

A second test pins the exact pair that broke, so a failure names the token instead of leaving someone to read a stack of selectors.

It costs about 3 seconds. The e2e suite goes from 260 tests to 260 including these, running in 9.5s.

**It fails when the bug returns.** Setting `--color-ink-faint` back to `#767386` fails 5 tests:

```
Element has insufficient color contrast of 4.26 (foreground color: #767386,
background color: #0b0b10, font size: 11.3pt (15px), font weight: normal).
Expected contrast ratio of 4.5:1
```

## What axe found

**Keyboard access on hand-authored code blocks.** A `CodeBlock.astro` body scrolls sideways but had no `tabindex`, so it could not be reached or scrolled by keyboard. Shiki already emits `tabindex="0"` on a fenced block in markdown, so the two halves of one anatomy had drifted apart. The component now sets it too.

**Four page-copy links distinguishable by colour alone.** On `/`, `/about/`, `/system/` and the tag pages. WCAG 1.4.1 wants 3:1 against the surrounding text or a second, non-colour cue, and the accent is 1.17:1 against body ink.

No colour can fix that one, which is worth stating precisely:

| requirement | needs luminance | possible? |
|---|---|---|
| 3:1 against `--color-ink-body`, brighter | 1.827 | no, above pure white |
| 3:1 against `--color-ink-body`, darker | ≤ 0.158 | yes, but then 3.76:1 against the page, under the 4.5 floor |

So the fix has to be a non-colour cue. It turns out the design already made that call: `Prose.astro` underlined every link in post prose, which is why no post was ever flagged. The four failures were page copy written in `.astro` files, outside the `Prose` component, which never picked the rule up.

So this reproduces the existing decision rather than inventing one. The underline moves out of `Prose.astro` into theme.css's base layer, keeping one source of truth, and now covers body copy everywhere:

```css
.prose a,
p a {
  text-decoration: underline;
  text-decoration-thickness: 1px;
  text-underline-offset: 2px;
  text-decoration-color: var(--color-line-accent);
}
```

Chrome, nav, the tab strip, listing rows and the post Outline carry no underline; none of them are inside a paragraph.

**Prose links do not change.** Computed styles before and after are identical:

```
prose link (post)  {"line":"underline","thick":"1px","off":"2px","col":"rgba(169, 139, 245, 0.4)"}
```

One link changes beyond the four: `↗ view raw .md` in the post footer, which now matches the rest of the body copy.

## Scope checked, not assumed

`ROUTES` samples 3 of the 30 posts, so I ran the link rule against all 30 plus every other template, 39 routes. Exactly 4 links, all of them page copy, none in post content.

## What this suite cannot judge

Axe returns "incomplete" rather than a pass for text it cannot resolve a background for. About 1.4% of text nodes land there, roughly 7,000 checked against 99 incomplete. Nearly all of it is the `COVER 2:3` labels sitting on the dither gradient on `/reading/`, plus the ASCII art, which has no text to read. Those still need an eye. Both docs now say so, rather than leaving a green run to imply full coverage.

## Verification

- `astro check`: 0 errors, 0 warnings.
- `npm test`: 38 passed.
- `npm run test:e2e`: 260 passed, 24 skipped.
- The `KNOWN` exception map is empty. Nothing is suppressed.
- Looked at `/about/`, `/` and a post footer at 1440 and 390.
