### PR TITLE
feat: a command palette behind ⌘K

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,9 @@ block or arrow glyph in post copy lands on it rather than on a system sans.
 
 **Code blocks emit one block element per line.** Newlines between inline elements are not reliable.
 
-**`.astro` by default.** React islands only for `CopyButton` and `OutlineDisclosure`. Adding a
-third island needs a reason.
+**`.astro` by default.** React islands only for `CopyButton`, `OutlineDisclosure` and
+`CommandPalette`, the ⌘K search overlay mounted once in `BaseLayout`. Adding a fourth island needs
+a reason.
 
 **Post URLs never change.** They are indexed and linked. Section pages may move with a 301 in
 `public/_redirects`.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -96,6 +96,10 @@ the accent is 1.17:1 against the prose it interrupts, and no colour fixes that, 
 3:1 WCAG asks for would need a lightness above white or one dark enough to fail 4.5:1 against the
 page. Chrome, nav, the tab strip and listing rows are not body copy and carry no underline.
 
+**Two values exist for the ⌘K palette alone**, and only in `theme.css`: `--color-scrim`
+(`rgb(9 9 13 / .78)`), the dimmed page it sits on, and `--color-line-palette`, the window line at
+50%. Nothing else uses them.
+
 **Radii are zero everywhere. Shadows do not exist.** The only depth cue is the 1px window border.
 
 Minimum contrast: no text below 4.5:1 against its own surface. Measured against
@@ -210,9 +214,13 @@ A flex row inside the window, below the chrome bar, on `--surface-tabbar`, botto
 with a right hairline.
 Mobile: `overflow-x: auto`, `scrollbar-width: none`, `flex: none` on every tab, real labels — never
 truncate a destination away.
+The strip ends in the `⌘K` cell (`SearchTrigger.astro`, `variant="tab"`), right-aligned and hidden
+below `md`. It inverts to `--surface-accent` while the palette is open. The six destinations come
+from `TABS` in `src/lib/nav.ts`, which `NavSheet` and the palette read as well.
 
 ### 7.4 Islands (React, `client:idle` unless noted)
 - `CopyButton.tsx` — the `[ COPY ]` control in a code block header. `client:visible`.
+- `CommandPalette.tsx`: the ⌘K search palette, mounted once in `BaseLayout`. See §7.17.
 - `OutlineDisclosure.tsx` — mobile outline toggle. Prefer native `<details>`; use the island only
   if you need the scroll-spy active state.
 
@@ -324,6 +332,38 @@ whole reading experience: console-voice headings with their `##` prefixes over J
 paragraphs.
 The post `h1` lives outside this component, in the route, so it stays Departure without a rule here.
 
+### 7.17 `CommandPalette.tsx` (island)
+The ⌘K overlay: search over posts, tags and pages, keyboard first. Mounted once in `BaseLayout`
+with `client:idle`, and the only island on most pages. Mockups 4a/4b/4c in
+`handoff/reference/mockups.html`.
+
+A `Window` centred over the scrim (`--color-scrim`), 660px wide, 96px from the top, capped at
+`calc(100vh - 192px)`, results scrolling inside. Its border is `--color-line-palette`, the window
+line lifted to 50%, because it floats over a dimmed page. Below 640px it is full screen.
+The chrome bar carries `⌘K`, the shell path, and a right-hand count: `N MATCHES`, `30 INDEXED` when
+the query is empty, `EXIT 1` on a miss. The input row is a prompt on `--surface-code` at
+`--text-lg`: `$` in the accent, `grep` in `--text-secondary`, the query in `--text-primary`, then a
+block caret one character wide at `left: <query.length>ch`. The input is real, with
+`caret-color: transparent`, because mobile keyboards and IME need it.
+Results group POSTS / TAGS / PAGES, each with a rule and a true total, capped at 5 / 3 / 3 rows.
+A row shows where it matched: nothing for a title (the match is visible), `matched #devops` for a
+tag, `matched dev in summary` for a description. Post bodies are not indexed.
+Selection is `--wash-accent-code` plus a 2px left `--surface-accent` bar, never the inverted fill
+the active tab uses: selection moves on every keypress and a fill would strobe. A selected row
+lifts its date and provenance from `--text-muted` to `--text-secondary`, because `--text-muted`
+measures 4.45:1 against that wash.
+Empty offers RECENT posts and a JUMP TO chip row of the six pages. A miss is a real error line,
+`grep: kubernetes: no matches in 30 files`, then one muted line, then the three highest-count tags
+as chips. Every chip is an option, so the arrow keys reach it.
+Keyboard: `⌘K`/`Ctrl+K` toggles, `/` opens when focus is outside a field, `↑` `↓` walk one flat
+list across the group rules and wrap, `Enter` opens, `Tab` cycles all → posts → tags → pages,
+`Backspace` on an empty query closes, `Esc` closes and returns focus to the trigger. Focus stays in
+the dialog because `Tab` never moves it.
+The index is a static `/search-index.json`, emitted by `src/pages/search-index.json.ts` at build
+time, 9.6 kB for 30 posts, 14 tags and 6 pages. It is fetched on first open, prefetched on hover or
+focus of a trigger, and cached in module scope. There is no search library: substring matching over
+this shape is enough, and a dependency here would be the largest thing on the site.
+
 ---
 
 ## 8. Page recipes
@@ -431,6 +471,6 @@ render showing every state), glyphs (safe vs fallback), still-open. Reference:
 
 ## 14. Open questions
 
-- The ⌘K command palette was dropped. Bruno's call — the hint came out of the tab bar and no
-  overlay was built.
+- Search beyond posts, tags and pages. The palette does not index the reading list or the courses,
+  and it does not read post bodies.
 - No search or pagination beyond "load older" has been designed.

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -110,6 +110,19 @@ allowed to exceed that, and only on pages where it is used.~~
 
 Check 9 is struck. Bruno chose a React island over the JS budget; the budget no longer applies.
 
+**10. The ⌘K palette.** Keyboard first, so screenshots alone will not catch what matters. Drive it
+with the mouse untouched: `⌘K` and `Ctrl+K` both open and are both prevented from reaching the
+browser; `/` opens outside a field and types itself inside one; `↑` `↓` walk one flat list across
+the group rules and wrap at both ends; `Enter` opens the selected URL; `Tab` cycles the group filter
+and never moves focus out of the dialog; `Backspace` on an empty query closes; `Esc` closes and
+`document.activeElement` is the trigger again. The document must not scroll while the selected row
+comes into view. Then check the states: `N MATCHES`, `30 INDEXED` empty, `EXIT 1` on a miss;
+selection is a wash plus a 2px left bar, never an inverted fill; 660px wide and 96px from the top
+above 640px, full screen below it with every row ≥44px; the footer is not clipped at 900px height.
+`tests/e2e/palette.spec.ts` encodes all of this, including axe and the glyph audit over the open
+palette. `tests/unit/search.test.ts` covers ranking and caps, and `tests/unit/search-index.test.ts`
+guards the index shape and its size.
+
 ## Per-route checklist
 
 | Route | Beyond the standard checks |

--- a/src/components/chrome/NavSheet.astro
+++ b/src/components/chrome/NavSheet.astro
@@ -1,5 +1,5 @@
 ---
-import { TABS } from './TabBar.astro';
+import { TABS } from '../../lib/nav';
 
 /**
  * The mobile menu. A native `<details>` so it works with no JavaScript.

--- a/src/components/chrome/SearchTrigger.astro
+++ b/src/components/chrome/SearchTrigger.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * The visible way into the ⌘K palette. `variant="tab"` is the cell at the
+ * right end of the tab strip on desktop; `variant="chrome"` is the mobile
+ * button in the chrome bar, because ⌘K does not exist on a phone.
+ *
+ * Both are server-rendered and carry `data-palette-open`. The island
+ * (src/components/islands/CommandPalette.tsx) listens for the click, sets
+ * `aria-expanded`, and prefetches the index on hover or focus.
+ *
+ * The chrome bar is 36px tall by design, so the mobile button reaches a 44px
+ * touch target through an expanded hit area rather than padding that would
+ * grow the bar.
+ */
+interface Props {
+  variant: 'tab' | 'chrome';
+}
+
+const { variant } = Astro.props;
+---
+
+{
+  variant === 'tab' ? (
+    <button
+      type="button"
+      data-palette-open
+      aria-label="Search"
+      aria-haspopup="dialog"
+      aria-expanded="false"
+      class="ml-auto hidden flex-none border-l border-line-faint px-4 py-[9px] text-2xs tracking-label text-ink-muted hover:text-accent-lift aria-expanded:bg-accent aria-expanded:text-on-accent md:block"
+    >
+      ⌘K
+    </button>
+  ) : (
+    <button
+      type="button"
+      data-palette-open
+      aria-label="Search"
+      aria-haspopup="dialog"
+      aria-expanded="false"
+      class="relative p-1 text-2xs tracking-chrome text-accent-lift after:absolute after:inset-[-9px] after:content-['']"
+    >
+      SEARCH
+    </button>
+  )
+}

--- a/src/components/chrome/TabBar.astro
+++ b/src/components/chrome/TabBar.astro
@@ -1,16 +1,6 @@
 ---
-/**
- * The six destinations of the site, in tab order. Shared with NavSheet so
- * the mobile menu never drifts from the tab strip.
- */
-export const TABS = [
-  { label: 'posts/', href: '/posts/' },
-  { label: 'about.md', href: '/about/' },
-  { label: 'src/', href: '/src/' },
-  { label: 'reading/', href: '/reading/' },
-  { label: 'courses/', href: '/courses/' },
-  { label: 'system/', href: '/system/' },
-] as const;
+import { TABS } from '../../lib/nav';
+import SearchTrigger from './SearchTrigger.astro';
 
 interface Props {
   current?: string;
@@ -40,4 +30,5 @@ const { current } = Astro.props;
       );
     })
   }
+  <SearchTrigger variant="tab" />
 </div>

--- a/src/components/chrome/Window.astro
+++ b/src/components/chrome/Window.astro
@@ -1,5 +1,6 @@
 ---
 import NavSheet from './NavSheet.astro';
+import SearchTrigger from './SearchTrigger.astro';
 
 /**
  * The frame every page lives in: chrome bar, tab strip and body.
@@ -32,7 +33,8 @@ const { title, dims, current } = Astro.props;
     <div class="ml-auto hidden items-center gap-3 text-2xs tracking-chrome text-ink-muted md:flex">
       <slot name="chrome-meta" />
     </div>
-    <div class="ml-auto md:hidden">
+    <div class="ml-auto flex items-center gap-3 md:hidden">
+      <SearchTrigger variant="chrome" />
       <NavSheet current={current} />
     </div>
   </div>

--- a/src/components/islands/CommandPalette.tsx
+++ b/src/components/islands/CommandPalette.tsx
@@ -1,0 +1,661 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  highlightParts,
+  postFilename,
+  recentPosts,
+  search,
+  topTags,
+  type Entry,
+  type Filter,
+  type PageEntry,
+  type Result,
+} from '../../lib/search';
+import { TABS } from '../../lib/nav';
+
+/**
+ * The ⌘K palette: a search window over the dimmed page, keyboard first.
+ * Mounted once in BaseLayout; opened by ⌘K, Ctrl+K, `/`, or either of the
+ * server-rendered `[data-palette-open]` buttons in the chrome.
+ *
+ * It redraws the chrome bar, prompt line, section rules and rows rather than
+ * importing Window, PromptLine, SectionRule and FileRow: those are `.astro`
+ * components and cannot render inside a React island. Every value here still
+ * comes from the same tokens, so the two stay in step.
+ */
+
+const INDEX_URL = '/search-index.json';
+const FILTERS: Filter[] = ['all', 'posts', 'tags', 'pages'];
+const OPTION_ID = 'palette-option';
+
+// Fetched on first open and kept for the life of the page: the index is
+// static, so a second fetch could only return the same bytes.
+let cached: Entry[] | null = null;
+let pending: Promise<Entry[]> | null = null;
+
+function loadIndex(): Promise<Entry[]> {
+  if (cached) return Promise.resolve(cached);
+  pending ??= fetch(INDEX_URL)
+    .then((res) => {
+      if (!res.ok) throw new Error(`${res.status}`);
+      return res.json() as Promise<Entry[]>;
+    })
+    .then((entries) => {
+      cached = entries;
+      return entries;
+    })
+    .catch((error) => {
+      pending = null;
+      throw error;
+    });
+  return pending;
+}
+
+/** True when a keystroke belongs to whatever the reader is typing in. */
+function inField(target: EventTarget | null): boolean {
+  return !!closestElement(target, 'input, textarea, select, [contenteditable]');
+}
+
+/**
+ * The nearest matching element, or null. Guards the instance check because
+ * `focusin` and `pointerenter` also fire with `document` as the target, which
+ * has no `closest`.
+ */
+function closestElement(target: EventTarget | null, selector: string): HTMLElement | null {
+  return target instanceof Element ? target.closest<HTMLElement>(selector) : null;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** The first trigger a reader can actually see: the tab cell, or the chrome button on a phone. */
+function visibleTrigger(): HTMLElement | null {
+  return (
+    [...document.querySelectorAll<HTMLElement>('[data-palette-open]')].find(
+      (el) => el.offsetParent !== null
+    ) ?? null
+  );
+}
+
+/** Where Esc should send focus when the palette was opened by a shortcut. */
+function restoreTarget(): HTMLElement | null {
+  const active = document.activeElement;
+  if (active instanceof HTMLElement && active !== document.body) return active;
+  return visibleTrigger();
+}
+
+/** The typed term, drawn in the accent wherever it appears. */
+function Highlight({ text, term }: { text: string; term: string }) {
+  return (
+    <>
+      {highlightParts(text, term).map((part, i) =>
+        part.hit ? (
+          <span key={i} className="text-accent-lift">
+            {part.text}
+          </span>
+        ) : (
+          <span key={i}>{part.text}</span>
+        )
+      )}
+    </>
+  );
+}
+
+export default function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [entries, setEntries] = useState<Entry[] | null>(cached);
+  const [failed, setFailed] = useState(false);
+  const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<Filter>('all');
+  const [selected, setSelected] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  const term = query.trim();
+  const isEmptyQuery = term === '';
+
+  const groups = useMemo(
+    () => (entries ? search(entries, query, filter) : []),
+    [entries, query, filter]
+  );
+  const matches = groups.reduce((sum, g) => sum + g.total, 0);
+  const noMatch = !isEmptyQuery && entries !== null && matches === 0;
+
+  const recent = useMemo(() => (entries ? recentPosts(entries) : []), [entries]);
+  const tags = useMemo(() => (entries ? topTags(entries) : []), [entries]);
+  const posts = useMemo(
+    () => (entries ? entries.filter((e) => e.kind === 'post').length : 0),
+    [entries]
+  );
+
+  // One flat list of destinations, in the order they are drawn. Arrow keys
+  // cross group boundaries and reach the chips too, so every offer in the
+  // palette is reachable without a mouse.
+  const rows: Result[] = useMemo(() => {
+    if (isEmptyQuery) {
+      return [
+        ...recent.map((entry) => ({ entry, matchedIn: 'title' as const, term: '' })),
+        ...TABS.map((tab) => ({
+          entry: {
+            kind: 'page' as const,
+            label: tab.label,
+            title: tab.title,
+            description: tab.description,
+            url: tab.href,
+          },
+          matchedIn: 'title' as const,
+          term: '',
+        })),
+      ];
+    }
+    if (noMatch) {
+      return tags.map((entry) => ({ entry, matchedIn: 'title' as const, term }));
+    }
+    return groups.flatMap((g) => g.results);
+  }, [isEmptyQuery, noMatch, recent, tags, groups, term]);
+
+  const move = useCallback(
+    (step: number) => {
+      setSelected((i) => (rows.length === 0 ? 0 : (i + step + rows.length) % rows.length));
+    },
+    [rows.length]
+  );
+
+  const cycleFilter = useCallback((step: number) => {
+    setFilter((f) => FILTERS[(FILTERS.indexOf(f) + step + FILTERS.length) % FILTERS.length]);
+    setSelected(0);
+  }, []);
+
+  // Opening is always an explicit action: a shortcut, or a click on one of
+  // the chrome triggers. The trigger is remembered so Esc can hand focus back.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const shortcut = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey);
+      if (shortcut) {
+        // ⌘K is the browser's own bookmark search on some platforms.
+        event.preventDefault();
+        if (!open) triggerRef.current = restoreTarget();
+        setOpen((was) => !was);
+        return;
+      }
+      if (!open && event.key === '/' && !inField(event.target) && !event.metaKey && !event.ctrlKey) {
+        event.preventDefault();
+        triggerRef.current = restoreTarget();
+        setOpen(true);
+      }
+    }
+
+    function onClick(event: MouseEvent) {
+      const trigger = closestElement(event.target, '[data-palette-open]');
+      if (!trigger) return;
+      triggerRef.current = trigger;
+      setOpen((was) => !was);
+    }
+
+    function prefetch(event: Event) {
+      if (closestElement(event.target, '[data-palette-open]')) {
+        loadIndex().catch(() => undefined);
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    document.addEventListener('click', onClick);
+    document.addEventListener('pointerenter', prefetch, true);
+    document.addEventListener('focusin', prefetch);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('click', onClick);
+      document.removeEventListener('pointerenter', prefetch, true);
+      document.removeEventListener('focusin', prefetch);
+    };
+  }, [open]);
+
+  // The chrome triggers are server-rendered, so their open state is set here.
+  useEffect(() => {
+    for (const trigger of document.querySelectorAll('[data-palette-open]')) {
+      trigger.setAttribute('aria-expanded', String(open));
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setFilter('all');
+    setSelected(0);
+    inputRef.current?.focus();
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || entries) return;
+    loadIndex().then(setEntries, () => setFailed(true));
+  }, [open, entries]);
+
+  // Keep the selected row in view inside the results pane. The dialog is
+  // fixed and the body cannot scroll, so the document never moves.
+  useEffect(() => {
+    resultsRef.current
+      ?.querySelector(`#${OPTION_ID}-${selected}`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [selected, rows]);
+
+  if (!open) return null;
+
+  function onDialogKeyDown(event: React.KeyboardEvent) {
+    switch (event.key) {
+      case 'Escape':
+        event.preventDefault();
+        close();
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        move(1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        move(-1);
+        break;
+      case 'Tab':
+        // Cycles the group filter rather than moving focus, which is also
+        // what keeps focus inside the dialog.
+        event.preventDefault();
+        cycleFilter(event.shiftKey ? -1 : 1);
+        break;
+      case 'Enter': {
+        const row = rows[selected];
+        if (!row) break;
+        event.preventDefault();
+        window.location.href = row.entry.url;
+        break;
+      }
+      case 'Backspace':
+        if (query === '') {
+          event.preventDefault();
+          close();
+        }
+        break;
+    }
+  }
+
+  const status = failed
+    ? 'EXIT 2'
+    : noMatch
+      ? 'EXIT 1'
+      : isEmptyQuery
+        ? `${posts} INDEXED`
+        : `${matches} MATCH${matches === 1 ? '' : 'ES'}`;
+
+  const announcement = failed
+    ? 'Search index unavailable'
+    : isEmptyQuery
+      ? ''
+      : `${matches} result${matches === 1 ? '' : 's'}`;
+
+  let index = -1;
+  const nextId = () => `${OPTION_ID}-${++index}`;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center">
+      <div className="absolute inset-0 bg-scrim" aria-hidden="true" onClick={close}></div>
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search"
+        onKeyDown={onDialogKeyDown}
+        className="relative flex h-full w-full flex-col border border-line-palette bg-surface-window sm:mt-24 sm:h-auto sm:max-h-[calc(100vh-192px)] sm:w-165"
+      >
+        <div className="flex items-center gap-2.25 border-b border-line-chrome bg-surface-chrome px-3 py-2.25 sm:gap-3 sm:px-3.5">
+          <span className="hidden text-2xs tracking-chrome text-accent-lift sm:inline">⌘K</span>
+          <span className="text-2xs tracking-chrome text-accent-lift sm:hidden">SEARCH</span>
+          <span className="text-2xs tracking-chrome text-ink-muted">
+            <span className="hidden sm:inline">bruno@bpaulino: ~ · search</span>
+            <span className="sm:hidden">bpaulino ~</span>
+          </span>
+          <span className="ml-auto hidden text-2xs tracking-chrome text-ink-muted sm:inline" aria-hidden="true">
+            {filter !== 'all' && `${filter.toUpperCase()} · `}
+            {status}
+          </span>
+          <button
+            type="button"
+            onClick={close}
+            className="ml-auto text-2xs tracking-chrome text-accent-lift sm:hidden"
+          >
+            CLOSE
+          </button>
+        </div>
+
+        <div className="flex items-center gap-2 border-b border-line-hairline bg-surface-code px-4 py-3.5 text-lg sm:px-4.5 sm:py-4">
+          <span className="text-accent">$</span>
+          <span className="hidden text-ink-secondary sm:inline">grep</span>
+          <div className="relative flex-1">
+            <input
+              ref={inputRef}
+              type="search"
+              role="combobox"
+              aria-expanded="true"
+              aria-controls="palette-results"
+              aria-activedescendant={rows.length ? `${OPTION_ID}-${selected}` : undefined}
+              aria-label="Search posts, tags and pages"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setSelected(0);
+              }}
+              // The block caret below is the design's cursor, so the
+              // native one is hidden. The input itself is real, because
+              // mobile keyboards and IME composition depend on it.
+              className="w-full appearance-none bg-transparent font-mono text-lg text-ink caret-transparent outline-none [&::-webkit-search-cancel-button]:hidden"
+            />
+            <span
+              aria-hidden="true"
+              // One character wide, at the end of the typed text: exact
+              // rather than approximate, because the face is monospaced.
+              style={{ left: `${query.length}ch` }}
+              className="caret pointer-events-none absolute top-0 h-5.5 w-[1ch] animate-blink bg-accent"
+            ></span>
+            {isEmptyQuery && (
+              <span className="pointer-events-none absolute left-[3ch] top-0.5 hidden text-sm text-ink-muted sm:inline">
+                search posts, tags and pages
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div
+          ref={resultsRef}
+          id="palette-results"
+          role="listbox"
+          aria-label="Search results"
+          // The scrollbar is hidden the same way the tab strip hides its own:
+          // the group counts say how much is there, and the arrow keys scroll.
+          className="flex-1 overflow-y-auto py-3.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
+          {failed && (
+            <div className="px-4 py-6 sm:px-4.5">
+              <p className="text-ink">grep: {INDEX_URL}: cannot open index</p>
+              <p className="mt-3.5 max-w-[50ch] text-sm text-ink-muted">
+                The search index did not load. Reload the page to try again, or press ESC and keep
+                reading.
+              </p>
+            </div>
+          )}
+
+          {!failed && isEmptyQuery && (
+            <>
+              <Rule label="RECENT" tight />
+              {recent.map((entry) => (
+                <PostRow key={entry.url} result={{ entry, matchedIn: 'title', term: '' }} id={nextId()} selected={index === selected} />
+              ))}
+              <Rule label="JUMP TO" />
+              <div role="none" className="flex flex-wrap gap-2 px-4 pb-2.5 pt-0.5 sm:px-4.5">
+                {TABS.map((tab) => (
+                  <Chip
+                    key={tab.href}
+                    href={tab.href}
+                    label={tab.label}
+                    id={nextId()}
+                    selected={index === selected}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+
+          {!failed && noMatch && (
+            <div className="px-4 pb-6 pt-3 sm:px-4.5">
+              <p className="text-ink">
+                grep: {term}: no matches in {posts} files
+              </p>
+              <p className="mt-3.5 max-w-[50ch] text-sm text-ink-muted">
+                Nothing on that yet. The closest tags are below, or press ESC and keep reading.
+              </p>
+              <div role="none" className="mt-4.5 flex flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <Chip
+                    key={tag.url}
+                    href={tag.url}
+                    label={`${tag.label} ${tag.count}`}
+                    id={nextId()}
+                    selected={index === selected}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {!failed &&
+            !isEmptyQuery &&
+            !noMatch &&
+            groups.map((group, groupIndex) => (
+              <div key={group.label} role="group" aria-label={group.label}>
+                <Rule label={group.label} meta={pad(group.total)} tight={groupIndex === 0} />
+                {group.results.map((result) => {
+                  const id = nextId();
+                  const isSelected = index === selected;
+                  if (result.entry.kind === 'post') {
+                    return <PostRow key={result.entry.url} result={result} id={id} selected={isSelected} />;
+                  }
+                  if (result.entry.kind === 'tag') {
+                    return <TagRow key={result.entry.url} result={result} id={id} selected={isSelected} />;
+                  }
+                  return <PageRow key={result.entry.url} result={result} id={id} selected={isSelected} />;
+                })}
+              </div>
+            ))}
+        </div>
+
+        <div className="hidden gap-5 border-t border-line-hairline bg-surface-tabbar px-4.5 py-2.5 text-2xs tracking-chrome text-ink-muted sm:flex">
+          {noMatch ? (
+            <span>
+              <span className="text-accent-lift">BACKSPACE</span> EDIT
+            </span>
+          ) : (
+            <>
+              <span>
+                <span className="text-accent-lift">↑↓</span> MOVE
+              </span>
+              <span>
+                <span className="text-accent-lift">ENTER</span> OPEN
+              </span>
+              <span>
+                <span className="text-accent-lift">TAB</span> FILTER
+              </span>
+            </>
+          )}
+          <span className="ml-auto">
+            <span className="text-accent-lift">ESC</span> CLOSE
+          </span>
+        </div>
+
+        <p className="sr-only" role="status" aria-live="polite">
+          {announcement}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/** `tight` drops the top gap: the first rule in the pane sits right under the input. */
+function Rule({ label, meta, tight }: { label: string; meta?: string; tight?: boolean }) {
+  return (
+    <div
+      className={`flex items-center gap-3.5 px-4 pb-2 sm:px-4.5 ${tight ? '' : 'pt-3.5'}`}
+    >
+      <span className="text-2xs tracking-section text-ink-muted">{label}</span>
+      <span className="h-px flex-1 bg-line" aria-hidden="true"></span>
+      {meta && <span className="text-2xs tracking-chrome text-ink-muted">{meta}</span>}
+    </div>
+  );
+}
+
+/**
+ * The shared row frame. Selection is a wash plus a 2px left accent bar, never
+ * the inverted fill the active tab uses: selection moves on every keypress and
+ * a fill would strobe.
+ */
+function Row({
+  href,
+  id,
+  selected,
+  children,
+}: {
+  href: string;
+  id: string;
+  selected: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      id={id}
+      role="option"
+      aria-selected={selected}
+      data-palette-row
+      className={`block min-h-11 border-l-2 px-4 py-3 sm:px-4.5 sm:py-2.75 ${
+        selected ? 'border-accent bg-wash-code' : 'border-transparent'
+      }`}
+    >
+      {children}
+    </a>
+  );
+}
+
+/**
+ * The colour of a row's secondary text. `--color-ink-muted` measures 4.45:1
+ * against the selection wash, just under the floor, so a selected row lifts
+ * its date and provenance to `--color-ink-secondary` (6.07:1).
+ */
+function metaInk(selected: boolean): string {
+  return selected ? 'text-ink-secondary' : 'text-ink-muted';
+}
+
+function PostRow({ result, id, selected }: { result: Result; id: string; selected: boolean }) {
+  const post = result.entry;
+  if (post.kind !== 'post') return null;
+  const provenance =
+    result.matchedIn === 'tag'
+      ? 'tag'
+      : result.matchedIn === 'description'
+        ? 'summary'
+        : null;
+  // The empty state's RECENT rows carry no query, so there is nothing to
+  // report about how they matched.
+  const quiet = result.term === '';
+
+  return (
+    <Row href={post.url} id={id} selected={selected}>
+      <div className="sm:flex sm:gap-3">
+        <span
+          className={`block text-2xs sm:whitespace-nowrap sm:pt-0.75 sm:text-xs ${metaInk(selected)}`}
+        >
+          {post.date}
+        </span>
+        <span className="mt-1.25 block sm:mt-0 sm:flex-1">
+          <span className="block text-ink">
+            <Highlight text={post.title} term={result.term} />
+          </span>
+          {!quiet && (
+          <span className={`mt-0.5 block text-xs ${metaInk(selected)}`}>
+            <span className="hidden sm:inline">{postFilename(post.url)}</span>
+            {provenance && (
+              <>
+                <span className="hidden sm:inline"> · </span>
+                matched{' '}
+                {provenance === 'tag' ? (
+                  <span className="text-accent-lift">
+                    #{post.tags.find((t) => t.includes(result.term.toLowerCase())) ?? result.term}
+                  </span>
+                ) : (
+                  <>
+                    <span className="text-accent-lift">{result.term}</span> in summary
+                  </>
+                )}
+              </>
+            )}
+          </span>
+          )}
+        </span>
+        {selected && (
+          <span className="hidden text-2xs tracking-chrome text-accent-lift sm:block sm:whitespace-nowrap sm:pt-1">
+            ENTER
+          </span>
+        )}
+      </div>
+    </Row>
+  );
+}
+
+function TagRow({ result, id, selected }: { result: Result; id: string; selected: boolean }) {
+  const tag = result.entry;
+  if (tag.kind !== 'tag') return null;
+  return (
+    <Row href={tag.url} id={id} selected={selected}>
+      <div className="flex items-baseline gap-3">
+        <span className="text-xs text-accent-lift">#{tag.label}</span>
+        <span className={`ml-auto text-xs sm:ml-0 sm:flex-1 ${metaInk(selected)}`}>
+          {tag.count} post{tag.count === 1 ? '' : 's'}
+          <span className="hidden sm:inline"> tagged {tag.label}</span>
+        </span>
+        <span className={`hidden text-2xs tracking-chrome sm:inline ${metaInk(selected)}`}>
+          {tag.url}
+        </span>
+      </div>
+    </Row>
+  );
+}
+
+function PageRow({ result, id, selected }: { result: Result; id: string; selected: boolean }) {
+  const page = result.entry as PageEntry;
+  return (
+    <Row href={page.url} id={id} selected={selected}>
+      <div className="sm:flex sm:items-baseline sm:gap-3">
+        <span className="text-ink">{page.label}</span>
+        <span className={`mt-1.25 block text-xs sm:mt-0 sm:flex-1 ${metaInk(selected)}`}>
+          <Highlight text={page.description} term={result.term} />
+        </span>
+      </div>
+    </Row>
+  );
+}
+
+/** A chip destination: the six pages when empty, the nearest tags on a miss. */
+function Chip({
+  href,
+  label,
+  id,
+  selected,
+}: {
+  href: string;
+  label: string;
+  id: string;
+  selected: boolean;
+}) {
+  return (
+    <a
+      href={href}
+      id={id}
+      role="option"
+      aria-selected={selected}
+      data-palette-row
+      className={`inline-flex min-h-11 items-center border px-2.75 py-1.25 text-xs sm:min-h-0 ${
+        selected ? 'border-accent text-accent-lift' : 'border-line-strong text-ink-body'
+      }`}
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import Scanlines from '../components/chrome/Scanlines.astro';
 import Window from '../components/chrome/Window.astro';
 import TabBar from '../components/chrome/TabBar.astro';
+import CommandPalette from '../components/islands/CommandPalette.tsx';
 
 /**
  * The shell every page renders inside: html head, page void, scanlines,
@@ -118,6 +119,7 @@ const windowTitle = `bruno@bpaulino: ${shellPath ?? derivedShellPath}`;
         </main>
       </Window>
     </div>
+    <CommandPalette client:idle />
     <script>
       // Copy control for markdown-derived code blocks (src/lib/rehype-code-block.ts).
       // CodeBlock.astro's own copy button is a React island (see

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,0 +1,44 @@
+/**
+ * The six destinations of the site, in tab order. The tab strip, the mobile
+ * menu and the ⌘K palette all read this list, so none of them can drift.
+ * `title` and `description` exist for the palette's PAGES rows; the tab
+ * strip shows only the label.
+ */
+export const TABS = [
+  {
+    label: 'posts/',
+    href: '/posts/',
+    title: 'Posts',
+    description: 'Every post, newest first',
+  },
+  {
+    label: 'about.md',
+    href: '/about/',
+    title: 'About',
+    description: 'Who I am and where my code runs',
+  },
+  {
+    label: 'src/',
+    href: '/src/',
+    title: 'Open Source',
+    description: 'Projects I maintain, from two Rust build cache servers to smaller tools',
+  },
+  {
+    label: 'reading/',
+    href: '/reading/',
+    title: 'Reading',
+    description: 'What I am reading now, and every book I finished',
+  },
+  {
+    label: 'courses/',
+    href: '/courses/',
+    title: 'Courses',
+    description: 'Programming courses I recorded, some of them free',
+  },
+  {
+    label: 'system/',
+    href: '/system/',
+    title: 'Design system',
+    description: 'CONSOLE: colour, type, components and glyphs, rendered live',
+  },
+] as const;

--- a/src/lib/search-index.ts
+++ b/src/lib/search-index.ts
@@ -1,0 +1,39 @@
+import { formatListDate } from './posts';
+import { TABS } from './nav';
+import type { Entry } from './search';
+
+/** The post fields the index carries. Narrow on purpose: no body, no front matter. */
+export interface IndexedPost {
+  id: string;
+  data: { title: string; description: string; date: Date; tags: readonly string[] };
+}
+
+/**
+ * Builds the ⌘K palette's index from posts and their tag counts. Pure, so a
+ * unit test can exercise it without a content collection.
+ */
+export function buildIndex(posts: IndexedPost[], counts: Map<string, number>): Entry[] {
+  return [
+    ...posts.map((post) => ({
+      kind: 'post' as const,
+      title: post.data.title,
+      description: post.data.description,
+      url: `/entries/${post.id}/`,
+      date: formatListDate(post.data.date),
+      tags: [...post.data.tags],
+    })),
+    ...[...counts].map(([label, count]) => ({
+      kind: 'tag' as const,
+      label,
+      url: `/tags/${label}/`,
+      count,
+    })),
+    ...TABS.map((tab) => ({
+      kind: 'page' as const,
+      label: tab.label,
+      title: tab.title,
+      description: tab.description,
+      url: tab.href,
+    })),
+  ];
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,157 @@
+/**
+ * The ⌘K palette's index shape and its matching rules. Pure: the island
+ * (src/components/islands/CommandPalette.tsx) fetches /search-index.json,
+ * emitted by src/pages/search-index.json.ts, and passes it through here.
+ *
+ * Post bodies are deliberately absent. Titles, descriptions and tags are
+ * what a reader searches a blog by, and leaving bodies out keeps the whole
+ * index under 10 kB.
+ */
+
+export interface PostEntry {
+  kind: 'post';
+  title: string;
+  description: string;
+  url: string;
+  /** YYYY-MM-DD, the form the listing rows show. */
+  date: string;
+  tags: string[];
+}
+
+export interface TagEntry {
+  kind: 'tag';
+  label: string;
+  url: string;
+  count: number;
+}
+
+export interface PageEntry {
+  kind: 'page';
+  /** The tab-bar name, e.g. `src/`. */
+  label: string;
+  title: string;
+  description: string;
+  url: string;
+}
+
+export type Entry = PostEntry | TagEntry | PageEntry;
+
+export type MatchedIn = 'title' | 'tag' | 'description';
+
+export interface Result {
+  entry: Entry;
+  matchedIn: MatchedIn;
+  /** The query as the reader typed it, for the highlight and the provenance line. */
+  term: string;
+}
+
+export type Filter = 'all' | 'posts' | 'tags' | 'pages';
+
+export interface Group {
+  label: 'POSTS' | 'TAGS' | 'PAGES';
+  /** Every match, including the ones the cap hides. */
+  total: number;
+  results: Result[];
+}
+
+const GROUPS = [
+  { kind: 'post', label: 'POSTS', filter: 'posts', cap: 5 },
+  { kind: 'tag', label: 'TAGS', filter: 'tags', cap: 3 },
+  { kind: 'page', label: 'PAGES', filter: 'pages', cap: 3 },
+] as const;
+
+const RANK: Record<MatchedIn, number> = { title: 0, tag: 1, description: 2 };
+
+const RECENT_COUNT = 3;
+const TOP_TAG_COUNT = 3;
+
+function matchEntry(entry: Entry, q: string): MatchedIn | null {
+  const has = (s: string) => s.toLowerCase().includes(q);
+  switch (entry.kind) {
+    case 'post':
+      if (has(entry.title)) return 'title';
+      if (entry.tags.some(has)) return 'tag';
+      if (has(entry.description)) return 'description';
+      return null;
+    case 'tag':
+      return has(entry.label) ? 'title' : null;
+    case 'page':
+      if (has(entry.label) || has(entry.title)) return 'title';
+      if (has(entry.description)) return 'description';
+      return null;
+  }
+}
+
+/** Compares two results of the same kind: strongest match first, then newest or most used. */
+function compare(a: Result, b: Result): number {
+  const byRank = RANK[a.matchedIn] - RANK[b.matchedIn];
+  if (byRank !== 0) return byRank;
+  if (a.entry.kind === 'post' && b.entry.kind === 'post') {
+    return b.entry.date.localeCompare(a.entry.date);
+  }
+  if (a.entry.kind === 'tag' && b.entry.kind === 'tag') {
+    return b.entry.count - a.entry.count;
+  }
+  return 0;
+}
+
+/**
+ * Matches a query against the index and returns the groups the palette draws.
+ * An empty query returns no groups: that is the palette's empty state, not a miss.
+ */
+export function search(index: Entry[], query: string, filter: Filter = 'all'): Group[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  return GROUPS.filter((g) => filter === 'all' || filter === g.filter)
+    .map(({ kind, label, cap }) => {
+      const results = index
+        .filter((entry) => entry.kind === kind)
+        .flatMap((entry) => {
+          const matchedIn = matchEntry(entry, q);
+          return matchedIn ? [{ entry, matchedIn, term: query.trim() }] : [];
+        })
+        .sort(compare);
+      return { label, total: results.length, results: results.slice(0, cap) };
+    })
+    .filter((g) => g.total > 0);
+}
+
+/** Splits text into runs, marking the ones that match the term, for the accent highlight. */
+export function highlightParts(text: string, term: string): { text: string; hit: boolean }[] {
+  const q = term.trim().toLowerCase();
+  if (!q) return [{ text, hit: false }];
+
+  const parts: { text: string; hit: boolean }[] = [];
+  let at = 0;
+  for (;;) {
+    const hit = text.toLowerCase().indexOf(q, at);
+    if (hit === -1) break;
+    if (hit > at) parts.push({ text: text.slice(at, hit), hit: false });
+    parts.push({ text: text.slice(hit, hit + q.length), hit: true });
+    at = hit + q.length;
+  }
+  if (at < text.length) parts.push({ text: text.slice(at), hit: false });
+  return parts.length ? parts : [{ text, hit: false }];
+}
+
+/** Renders a post URL as the markdown file it was written in. */
+export function postFilename(url: string): string {
+  return `${url.replace(/\/$/, '').split('/').pop()}.md`;
+}
+
+/** The newest posts, newest first. The palette's empty state offers these. */
+export function recentPosts(index: Entry[], limit = RECENT_COUNT): PostEntry[] {
+  return index
+    .filter((e): e is PostEntry => e.kind === 'post')
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, limit);
+}
+
+/** The most used tags, most used first. The no-match state offers these as the way out. */
+export function topTags(index: Entry[], limit = TOP_TAG_COUNT): TagEntry[] {
+  return index
+    .filter((e): e is TagEntry => e.kind === 'tag')
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,8 +1,7 @@
 import type { APIRoute } from 'astro';
-import { getPosts, formatListDate } from '../lib/posts';
+import { getPosts } from '../lib/posts';
 import { tagCounts } from '../lib/tags';
-import { TABS } from '../lib/nav';
-import type { Entry } from '../lib/search';
+import { buildIndex } from '../lib/search-index';
 
 /**
  * The ⌘K palette's index, written to /search-index.json at build time. The
@@ -10,33 +9,8 @@ import type { Entry } from '../lib/search';
  */
 export const GET: APIRoute = async () => {
   const posts = await getPosts();
-  const counts = tagCounts(posts);
 
-  const entries: Entry[] = [
-    ...posts.map((post) => ({
-      kind: 'post' as const,
-      title: post.data.title,
-      description: post.data.description,
-      url: `/entries/${post.id}/`,
-      date: formatListDate(post.data.date),
-      tags: [...post.data.tags],
-    })),
-    ...[...counts].map(([label, count]) => ({
-      kind: 'tag' as const,
-      label,
-      url: `/tags/${label}/`,
-      count,
-    })),
-    ...TABS.map((tab) => ({
-      kind: 'page' as const,
-      label: tab.label,
-      title: tab.title,
-      description: tab.description,
-      url: tab.href,
-    })),
-  ];
-
-  return new Response(JSON.stringify(entries), {
+  return new Response(JSON.stringify(buildIndex(posts, tagCounts(posts))), {
     headers: { 'Content-Type': 'application/json' },
   });
 };

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from 'astro';
+import { getPosts, formatListDate } from '../lib/posts';
+import { tagCounts } from '../lib/tags';
+import { TABS } from '../lib/nav';
+import type { Entry } from '../lib/search';
+
+/**
+ * The ⌘K palette's index, written to /search-index.json at build time. The
+ * palette fetches it on first open, so it must never be inlined into a page.
+ */
+export const GET: APIRoute = async () => {
+  const posts = await getPosts();
+  const counts = tagCounts(posts);
+
+  const entries: Entry[] = [
+    ...posts.map((post) => ({
+      kind: 'post' as const,
+      title: post.data.title,
+      description: post.data.description,
+      url: `/entries/${post.id}/`,
+      date: formatListDate(post.data.date),
+      tags: [...post.data.tags],
+    })),
+    ...[...counts].map(([label, count]) => ({
+      kind: 'tag' as const,
+      label,
+      url: `/tags/${label}/`,
+      count,
+    })),
+    ...TABS.map((tab) => ({
+      kind: 'page' as const,
+      label: tab.label,
+      title: tab.title,
+      description: tab.description,
+      url: tab.href,
+    })),
+  ];
+
+  return new Response(JSON.stringify(entries), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/system.astro
+++ b/src/pages/system.astro
@@ -100,7 +100,7 @@ const FALLBACK_GLYPHS = ['●', '▶', '▚', '✓', '★', '⧉', '≡', '✕',
 const COMPONENTS = [
   'PromptLine + Caret', 'SectionRule', 'Tag', 'FileRow', 'Pagination',
   'CodeBlock', 'Callout', 'BookCover', 'AsciiBanner', 'Outline', 'Prose',
-  'Window · TabBar · Scanlines',
+  'Window · TabBar · Scanlines', 'CommandPalette',
 ];
 
 const outlineHeadings = [
@@ -469,6 +469,31 @@ const outlineHeadings = [
       the tab strip below it is highlighting <span class="text-accent-lift">system/</span> right now.
       Squares, never circles. The third one is the accent.
     </p>
+  </div>
+
+  <div class="grid gap-5 border-t border-line-hairline py-5 sm:grid-cols-[200px_1fr] [&>*]:min-w-0">
+    <div>
+      <div class="text-md text-ink">CommandPalette</div>
+      <div class="mt-1.5 text-xs leading-snug text-ink-muted">Search over {posts.length} posts, {counts.size} tags and 6 pages. Selection is a wash plus a left accent bar, never the inverted fill the active tab uses: it moves on every keypress and a fill would strobe.</div>
+      <div class="mt-2 text-2xs tracking-chrome text-ink-muted">islands/CommandPalette.tsx · REACT</div>
+    </div>
+    <div class="flex flex-col items-start gap-3 border border-line-hairline bg-surface-code px-5 py-4.5">
+      <button
+        type="button"
+        data-palette-open
+        aria-haspopup="dialog"
+        aria-expanded="false"
+        class="border border-line-strong px-3 py-2 text-2xs tracking-chrome text-accent-lift hover:border-line-accent"
+      >
+        OPEN SEARCH
+      </button>
+      <p class="text-sm text-ink-body">
+        The same palette every page carries: <span class="text-accent-lift">⌘K</span> or{' '}
+        <span class="text-accent-lift">/</span> anywhere, the <span class="text-accent-lift">⌘K</span>{' '}
+        cell at the end of the tab strip, or <span class="text-accent-lift">SEARCH</span> in the chrome
+        bar on a phone. Arrow keys cross the group rules, TAB narrows to one group, ESC closes.
+      </p>
+    </div>
   </div>
 
   <!-- ============================================================ -->

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -45,6 +45,13 @@
   --color-line-hairline:   rgb(228 226 234 / .10);
   --color-line-faint:      rgb(228 226 234 / .06);
 
+  /* Two values tokens.css does not carry, both from the ⌘K palette handoff
+     (mockup 4a): the scrim the palette sits on, and its border, which is
+     --color-line-window lifted to 50% because the palette floats over a
+     dimmed page and needs the extra definition. */
+  --color-scrim:           rgb(9 9 13 / .78);
+  --color-line-palette:    rgb(169 139 245 / .50);
+
   --color-wash-accent:     rgb(169 139 245 / .07);
   --color-wash-code:       rgb(169 139 245 / .14);
   --color-wash-scan:       rgb(169 139 245 / .05);

--- a/tests/e2e/palette.spec.ts
+++ b/tests/e2e/palette.spec.ts
@@ -1,0 +1,313 @@
+import AxeBuilder from '@axe-core/playwright';
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * The ⌘K palette. It is keyboard-first, so most of this drives the keyboard
+ * and never touches the mouse. Runs in the `desktop` and `mobile` projects;
+ * the checks that depend on width say so.
+ */
+
+const DESKTOP_ONLY = 'the palette is centred and 660px wide only above 640px';
+const MOBILE_ONLY = 'full screen, and the visible trigger lives in the chrome bar';
+
+function isMobile(page: Page): boolean {
+  return (page.viewportSize()?.width ?? 0) < 640;
+}
+
+/**
+ * The island hydrates on idle, so nothing is bound to ⌘K until it has. A
+ * hydrated `astro-island` drops its `ssr` attribute, which is the signal.
+ */
+async function load(page: Page) {
+  await page.goto('/posts/');
+  // `attached`, not the default `visible`: the island renders nothing until
+  // it is opened, so the element has no box to be visible.
+  await page.waitForSelector('astro-island[component-url*="CommandPalette"]:not([ssr])', {
+    state: 'attached',
+  });
+  await page.evaluate(() => document.fonts.ready);
+}
+
+/** Opens the palette with ⌘K and waits for the index to land. */
+async function open(page: Page, query?: string) {
+  await load(page);
+  await page.keyboard.press('Meta+k');
+  await expect(page.locator('[role=dialog]')).toBeVisible();
+  await expect(page.locator('[role=option]').first()).toBeVisible();
+  if (query) {
+    await page.locator('[role=combobox]').pressSequentially(query);
+    await expect(page.locator('[role=option]').first()).toBeVisible();
+  }
+}
+
+const selectedText = (page: Page) => page.locator('[role=option][aria-selected=true]').innerText();
+
+test.describe('opening and closing', () => {
+  test('⌘K opens with the input focused, and closes again', async ({ page }) => {
+    await open(page);
+    expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).toBe('combobox');
+    await page.keyboard.press('Meta+k');
+    await expect(page.locator('[role=dialog]')).toHaveCount(0);
+  });
+
+  test('Ctrl+K opens too', async ({ page }) => {
+    await load(page);
+    await page.keyboard.press('Control+k');
+    await expect(page.locator('[role=dialog]')).toBeVisible();
+  });
+
+  test('/ opens when focus is outside a field, and types itself when inside one', async ({ page }) => {
+    await load(page);
+    await page.keyboard.press('/');
+    await expect(page.locator('[role=dialog]')).toBeVisible();
+    await page.locator('[role=combobox]').pressSequentially('/');
+    await expect(page.locator('[role=combobox]')).toHaveValue('/');
+  });
+
+  test('Escape closes and hands focus back to the trigger', async ({ page }) => {
+    await load(page);
+    const trigger = page.locator('[data-palette-open]:visible');
+    await trigger.click();
+    await expect(page.locator('[role=dialog]')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[role=dialog]')).toHaveCount(0);
+    expect(await page.evaluate(() => document.activeElement?.getAttribute('data-palette-open')))
+      .toBe('');
+  });
+
+  test('Backspace on an empty query closes', async ({ page }) => {
+    await open(page, 'dev');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+    await expect(page.locator('[role=dialog]')).toBeVisible();
+    await page.keyboard.press('Backspace');
+    await expect(page.locator('[role=dialog]')).toHaveCount(0);
+  });
+
+  test('a click on the dimmer closes', async ({ page }) => {
+    test.skip(isMobile(page), MOBILE_ONLY);
+    await open(page);
+    await page.mouse.click(20, 20);
+    await expect(page.locator('[role=dialog]')).toHaveCount(0);
+  });
+});
+
+test.describe('keyboard navigation', () => {
+  test('the first result is selected on every keystroke', async ({ page }) => {
+    await open(page, 'dev');
+    const first = page.locator('[role=option]').first();
+    await expect(first).toHaveAttribute('aria-selected', 'true');
+    await page.keyboard.press('ArrowDown');
+    await expect(first).toHaveAttribute('aria-selected', 'false');
+    await page.locator('[role=combobox]').pressSequentially('o');
+    await expect(page.locator('[role=option]').first()).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('arrows cross group boundaries: groups are visual, not navigational', async ({ page }) => {
+    await open(page, 'dev');
+    const groups = page.locator('[role=group]');
+    await expect(groups).toHaveCount(2); // POSTS and TAGS
+    const postCount = await groups.first().locator('[role=option]').count();
+    for (let i = 0; i < postCount; i++) await page.keyboard.press('ArrowDown');
+    await expect(groups.nth(1).locator('[role=option][aria-selected=true]')).toHaveCount(1);
+  });
+
+  test('arrows wrap at both ends', async ({ page }) => {
+    await open(page, 'dev');
+    const first = await selectedText(page);
+    const total = await page.locator('[role=option]').count();
+    for (let i = 0; i < total; i++) await page.keyboard.press('ArrowDown');
+    expect(await selectedText(page)).toBe(first);
+    await page.keyboard.press('ArrowUp');
+    expect(await selectedText(page)).toBe(await page.locator('[role=option]').last().innerText());
+  });
+
+  test('Enter opens the selected result', async ({ page }) => {
+    await open(page, 'homelab');
+    const href = await page.locator('[role=option][aria-selected=true]').getAttribute('href');
+    await page.keyboard.press('Enter');
+    await page.waitForURL(`**${href}`);
+    expect(new URL(page.url()).pathname).toBe(href);
+  });
+
+  test('Tab cycles the group filter instead of moving focus', async ({ page }) => {
+    await open(page, 'dev');
+    await page.keyboard.press('Tab');
+    expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).toBe('combobox');
+    await expect(page.locator('[role=group]')).toHaveCount(1);
+    await expect(page.locator('[role=group]')).toHaveAttribute('aria-label', 'POSTS');
+    await page.keyboard.press('Tab');
+    await expect(page.locator('[role=group]')).toHaveAttribute('aria-label', 'TAGS');
+    await page.keyboard.press('Tab');
+    await expect(page.locator('[role=group]')).toHaveCount(0); // no page matches "dev"
+    await page.keyboard.press('Tab');
+    await expect(page.locator('[role=group]')).toHaveCount(2); // back to all
+  });
+
+  test('the selected row scrolls into view without moving the document', async ({ page }) => {
+    await open(page, 'e');
+    const before = await page.evaluate(() => document.documentElement.scrollTop);
+    const total = await page.locator('[role=option]').count();
+    for (let i = 0; i < total - 1; i++) await page.keyboard.press('ArrowDown');
+    await expect(page.locator('[role=option]').last()).toBeInViewport();
+    expect(await page.evaluate(() => document.documentElement.scrollTop)).toBe(before);
+  });
+});
+
+test.describe('states', () => {
+  test('the chrome count reads INDEXED, MATCHES then EXIT 1', async ({ page }) => {
+    await open(page);
+    const chrome = page.locator('[role=dialog] [aria-hidden=true]', { hasText: /INDEXED|MATCH|EXIT/ });
+    test.skip(isMobile(page), DESKTOP_ONLY);
+    await expect(chrome).toHaveText('30 INDEXED');
+    await page.locator('[role=combobox]').pressSequentially('homelab');
+    await expect(chrome).toContainText('MATCHES');
+    await page.locator('[role=combobox]').pressSequentially('zzz');
+    await expect(chrome).toHaveText('EXIT 1');
+  });
+
+  test('the empty state offers recent posts and the six pages', async ({ page }) => {
+    await open(page);
+    await expect(page.locator('[role=listbox]')).toContainText('RECENT');
+    await expect(page.locator('[role=listbox]')).toContainText('JUMP TO');
+    await expect(page.locator('[role=option]')).toHaveCount(9); // 3 posts + 6 pages
+  });
+
+  test('a miss is a grep error, and every tag it offers is reachable', async ({ page }) => {
+    await open(page, 'kubernetes');
+    await expect(page.locator('[role=listbox]')).toContainText('grep: kubernetes: no matches in 30 files');
+    await expect(page.locator('[role=option]')).toHaveCount(3);
+    await expect(page.locator('[role=option][aria-selected=true]')).toHaveCount(1);
+  });
+
+  test('selection is a wash plus a left accent bar, never an inverted fill', async ({ page }) => {
+    await open(page, 'dev');
+    const style = await page.locator('[role=option][aria-selected=true]').evaluate((el) => {
+      const s = getComputedStyle(el);
+      return { background: s.backgroundColor, border: s.borderLeftWidth, colour: s.borderLeftColor };
+    });
+    expect(style.background).toBe('rgba(169, 139, 245, 0.14)'); // --color-wash-code
+    expect(style.border).toBe('2px');
+    expect(style.colour).toBe('rgb(169, 139, 245)'); // --color-accent
+  });
+});
+
+test.describe('geometry', () => {
+  test('660px wide, 96px from the top, with the footer in view', async ({ page }) => {
+    test.skip(isMobile(page), DESKTOP_ONLY);
+    await open(page, 'e');
+    const box = (await page.locator('[role=dialog]').boundingBox())!;
+    expect(box.width).toBe(660);
+    expect(box.y).toBe(96);
+    expect(box.y + box.height).toBeLessThanOrEqual(page.viewportSize()!.height);
+    await expect(page.locator('[role=dialog]').getByText('ESC CLOSE')).toBeInViewport();
+  });
+
+  test('full screen on a phone, with rows at least 44px tall', async ({ page }) => {
+    test.skip(!isMobile(page), MOBILE_ONLY);
+    await open(page, 'dev');
+    const viewport = page.viewportSize()!;
+    const box = (await page.locator('[role=dialog]').boundingBox())!;
+    expect(box.width).toBe(viewport.width);
+    expect(box.height).toBe(viewport.height);
+    for (const row of await page.locator('[role=option]').all()) {
+      expect((await row.boundingBox())!.height).toBeGreaterThanOrEqual(44);
+    }
+  });
+
+  test('the mobile trigger is a real, visible, labelled button', async ({ page }) => {
+    test.skip(!isMobile(page), MOBILE_ONLY);
+    await load(page);
+    const trigger = page.locator('button[data-palette-open]:visible');
+    await expect(trigger).toHaveCount(1);
+    await expect(trigger).toHaveAccessibleName('Search');
+    await expect(trigger).toHaveText('SEARCH');
+  });
+});
+
+test.describe('accessibility', () => {
+  test('the combobox points at exactly one live option', async ({ page }) => {
+    await open(page, 'dev');
+    const state = await page.evaluate(() => {
+      const input = document.querySelector('[role=combobox]')!;
+      const active = input.getAttribute('aria-activedescendant');
+      return {
+        expanded: input.getAttribute('aria-expanded'),
+        controls: input.getAttribute('aria-controls'),
+        activeExists: !!document.getElementById(active ?? ''),
+        selected: document.querySelectorAll('[role=option][aria-selected=true]').length,
+        dialog: !!document.querySelector('[role=dialog][aria-modal=true]'),
+        listbox: !!document.querySelector('[role=listbox]'),
+      };
+    });
+    expect(state).toEqual({
+      expanded: 'true',
+      controls: 'palette-results',
+      activeExists: true,
+      selected: 1,
+      dialog: true,
+      listbox: true,
+    });
+  });
+
+  test('the result count is announced politely', async ({ page }) => {
+    await open(page, 'homelab');
+    const live = page.locator('[role=status][aria-live=polite]');
+    await expect(live).toHaveText(/^\d+ results?$/);
+  });
+
+  test('the caret and the dimmer are hidden from the reader', async ({ page }) => {
+    await open(page);
+    await expect(page.locator('[role=dialog] .caret')).toHaveAttribute('aria-hidden', 'true');
+    await expect(page.locator('.bg-scrim')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('axe reports no WCAG A/AA violations over the open palette', async ({ page }) => {
+    await open(page, 'dev');
+    const { violations } = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+    expect(violations.map((v) => `${v.id}: ${v.help}`)).toEqual([]);
+  });
+
+  test('every glyph in the open palette comes from Departure Mono', async ({ page }) => {
+    await open(page, 'dev');
+    const fallbacks = await page.evaluate(() => {
+      const probe = (ch: string) => {
+        const s = document.createElement('span');
+        s.style.cssText = 'font:100px "Departure Mono";position:absolute;visibility:hidden';
+        s.textContent = ch;
+        document.body.append(s);
+        const w = s.getBoundingClientRect().width;
+        s.remove();
+        return w;
+      };
+      const M = probe('M');
+      const dialog = document.querySelector<HTMLElement>('[role=dialog]')!;
+      const used = [...new Set(dialog.innerText)].filter((c) => c.trim());
+      return used.filter((c) => Math.abs(probe(c) - M) > 0.5);
+    });
+    expect(fallbacks, `these fell back to a system font: ${fallbacks.join(' ')}`).toEqual([]);
+  });
+});
+
+test.describe('reduced motion', () => {
+  // `test.use({ reducedMotion: 'reduce' })` does not reach Chromium's media
+  // emulation in this Playwright version. See the note in motion.spec.ts.
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+  });
+
+  test('the caret is visible and static, not stuck mid-blink', async ({ page }) => {
+    await open(page);
+    const caret = page.locator('[role=dialog] .caret');
+    await expect(caret).toBeVisible();
+    const style = await caret.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return { opacity: s.opacity, duration: s.animationDuration };
+    });
+    expect(style.opacity).toBe('1');
+    expect(parseFloat(style.duration)).toBeLessThan(0.01);
+  });
+});

--- a/tests/e2e/palette.spec.ts
+++ b/tests/e2e/palette.spec.ts
@@ -93,6 +93,27 @@ test.describe('opening and closing', () => {
   });
 });
 
+test.describe('the index', () => {
+  // Against the built file, because the numbers are about real content: the
+  // unit tests cover the transform, this covers what the build emitted.
+  test('/search-index.json holds every post, tag and page, and stays small', async ({ request }) => {
+    const response = await request.get('/search-index.json');
+    expect(response.headers()['content-type']).toContain('application/json');
+
+    const body = await response.body();
+    const entries = JSON.parse(body.toString());
+    const count = (kind: string) => entries.filter((e: { kind: string }) => e.kind === kind).length;
+
+    expect(count('post')).toBe(30);
+    expect(count('tag')).toBe(14);
+    expect(count('page')).toBe(6);
+    for (const entry of entries) expect(entry).not.toHaveProperty('body');
+    // The handoff's budget is 60 kB uncompressed. Without post bodies it is
+    // nowhere near, and this fails long before the palette gets slow to open.
+    expect(body.byteLength).toBeLessThan(20_000);
+  });
+});
+
 test.describe('keyboard navigation', () => {
   test('the first result is selected on every keystroke', async ({ page }) => {
     await open(page, 'dev');

--- a/tests/unit/search-index.test.ts
+++ b/tests/unit/search-index.test.ts
@@ -1,51 +1,78 @@
 import { describe, it, expect } from 'vitest';
-import { GET } from '../../src/pages/search-index.json';
-import { TAG_ORDER } from '../../src/lib/tags';
+import { buildIndex, type IndexedPost } from '../../src/lib/search-index';
 import { TABS } from '../../src/lib/nav';
-import type { Entry } from '../../src/lib/search';
 
-const response = await GET({} as never);
-const json = await response.text();
-const entries: Entry[] = JSON.parse(json);
+// Fixtures, not the real collection: `astro:content` is empty until a build
+// has synced it, and a unit test that depends on that state passes on a warm
+// checkout and fails on a cold one. The real emitted file is checked in
+// tests/e2e/palette.spec.ts, against a build.
+const posts: IndexedPost[] = [
+  {
+    id: 'https-for-your-homelab',
+    data: {
+      title: 'HTTPS for your homelab',
+      description: 'Split-horizon DNS at home',
+      date: new Date('2026-04-19'),
+      tags: ['security', 'homelab'],
+    },
+  },
+  {
+    id: 'dev-previews',
+    data: {
+      title: 'Why deployment previews?',
+      description: 'Every branch gets a URL',
+      date: new Date('2025-03-26'),
+      tags: ['devops'],
+    },
+  },
+];
 
-const of = <K extends Entry['kind']>(kind: K) =>
-  entries.filter((e): e is Extract<Entry, { kind: K }> => e.kind === kind);
+const counts = new Map([
+  ['security', 1],
+  ['homelab', 1],
+  ['devops', 1],
+]);
 
-describe('/search-index.json', () => {
-  it('is served as JSON', () => {
-    expect(response.headers.get('content-type')).toContain('application/json');
+const entries = buildIndex(posts, counts);
+const of = <K extends (typeof entries)[number]['kind']>(kind: K) =>
+  entries.filter((e): e is Extract<(typeof entries)[number], { kind: K }> => e.kind === kind);
+
+describe('buildIndex', () => {
+  it('indexes every post at its entry URL, dated YYYY-MM-DD', () => {
+    expect(of('post')).toEqual([
+      {
+        kind: 'post',
+        title: 'HTTPS for your homelab',
+        description: 'Split-horizon DNS at home',
+        url: '/entries/https-for-your-homelab/',
+        date: '2026-04-19',
+        tags: ['security', 'homelab'],
+      },
+      {
+        kind: 'post',
+        title: 'Why deployment previews?',
+        description: 'Every branch gets a URL',
+        url: '/entries/dev-previews/',
+        date: '2025-03-26',
+        tags: ['devops'],
+      },
+    ]);
   });
 
-  it('indexes every published post', () => {
-    expect(of('post')).toHaveLength(30);
+  it('indexes every tag with its count and its page', () => {
+    expect(of('tag')).toEqual([
+      { kind: 'tag', label: 'security', url: '/tags/security/', count: 1 },
+      { kind: 'tag', label: 'homelab', url: '/tags/homelab/', count: 1 },
+      { kind: 'tag', label: 'devops', url: '/tags/devops/', count: 1 },
+    ]);
   });
 
-  it('indexes every tag with its post count', () => {
-    const tags = of('tag');
-    expect(tags).toHaveLength(TAG_ORDER.length);
-    for (const tag of tags) {
-      expect(tag.url).toBe(`/tags/${tag.label}/`);
-      expect(tag.count).toBeGreaterThan(0);
-    }
-  });
-
-  it('indexes the six pages of the tab bar', () => {
+  it('indexes the six destinations of the tab bar, in tab order', () => {
     expect(of('page').map((p) => p.url)).toEqual(TABS.map((t) => t.href));
-  });
-
-  it('points every post at its entry URL and dates it YYYY-MM-DD', () => {
-    for (const post of of('post')) {
-      expect(post.url).toMatch(/^\/entries\/[a-z0-9-]+\/$/);
-      expect(post.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-      expect(post.tags.length).toBeGreaterThan(0);
-    }
+    expect(of('page').map((p) => p.label)).toEqual(TABS.map((t) => t.label));
   });
 
   it('carries no post body', () => {
     for (const entry of entries) expect(entry).not.toHaveProperty('body');
-  });
-
-  it('stays well under the 60 kB budget', () => {
-    expect(new TextEncoder().encode(json).length).toBeLessThan(20_000);
   });
 });

--- a/tests/unit/search-index.test.ts
+++ b/tests/unit/search-index.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from '../../src/pages/search-index.json';
+import { TAG_ORDER } from '../../src/lib/tags';
+import { TABS } from '../../src/lib/nav';
+import type { Entry } from '../../src/lib/search';
+
+const response = await GET({} as never);
+const json = await response.text();
+const entries: Entry[] = JSON.parse(json);
+
+const of = <K extends Entry['kind']>(kind: K) =>
+  entries.filter((e): e is Extract<Entry, { kind: K }> => e.kind === kind);
+
+describe('/search-index.json', () => {
+  it('is served as JSON', () => {
+    expect(response.headers.get('content-type')).toContain('application/json');
+  });
+
+  it('indexes every published post', () => {
+    expect(of('post')).toHaveLength(30);
+  });
+
+  it('indexes every tag with its post count', () => {
+    const tags = of('tag');
+    expect(tags).toHaveLength(TAG_ORDER.length);
+    for (const tag of tags) {
+      expect(tag.url).toBe(`/tags/${tag.label}/`);
+      expect(tag.count).toBeGreaterThan(0);
+    }
+  });
+
+  it('indexes the six pages of the tab bar', () => {
+    expect(of('page').map((p) => p.url)).toEqual(TABS.map((t) => t.href));
+  });
+
+  it('points every post at its entry URL and dates it YYYY-MM-DD', () => {
+    for (const post of of('post')) {
+      expect(post.url).toMatch(/^\/entries\/[a-z0-9-]+\/$/);
+      expect(post.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(post.tags.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('carries no post body', () => {
+    for (const entry of entries) expect(entry).not.toHaveProperty('body');
+  });
+
+  it('stays well under the 60 kB budget', () => {
+    expect(new TextEncoder().encode(json).length).toBeLessThan(20_000);
+  });
+});

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  search,
+  highlightParts,
+  postFilename,
+  recentPosts,
+  topTags,
+  type Entry,
+} from '../../src/lib/search';
+
+const post = (
+  title: string,
+  description: string,
+  date: string,
+  tags: string[] = ['devops']
+): Entry => ({
+  kind: 'post',
+  title,
+  description,
+  url: `/entries/${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}/`,
+  date,
+  tags,
+});
+
+const INDEX: Entry[] = [
+  post('HTTPS for your homelab', 'Local network speeds', '2026-04-19', ['security', 'homelab']),
+  post('Distributed locks in Node.js', 'Redis and DNS lookups', '2023-07-23', ['typescript']),
+  post('Taming ambiguity', 'How to lead without a spec', '2024-11-02', ['leadership', 'homelab']),
+  post('Dev previews', 'Every branch gets a homelab URL', '2025-03-26', ['devops']),
+  { kind: 'tag', label: 'homelab', url: '/tags/homelab/', count: 2 },
+  { kind: 'tag', label: 'leadership', url: '/tags/leadership/', count: 8 },
+  { kind: 'tag', label: 'devops', url: '/tags/devops/', count: 5 },
+  { kind: 'page', label: 'src/', title: 'Open Source', description: 'Homelab configs and tools', url: '/src/' },
+  { kind: 'page', label: 'about.md', title: 'About', description: 'Who I am', url: '/about/' },
+];
+
+describe('search', () => {
+  it('returns nothing for an empty query', () => {
+    expect(search(INDEX, '')).toEqual([]);
+    expect(search(INDEX, '   ')).toEqual([]);
+  });
+
+  it('groups results as POSTS, TAGS then PAGES', () => {
+    expect(search(INDEX, 'homelab').map((g) => g.label)).toEqual(['POSTS', 'TAGS', 'PAGES']);
+  });
+
+  it('omits a group with no matches', () => {
+    expect(search(INDEX, 'ambiguity').map((g) => g.label)).toEqual(['POSTS']);
+  });
+
+  it('matches regardless of case', () => {
+    const urls = (q: string) => search(INDEX, q).flatMap((g) => g.results.map((r) => r.entry.url));
+    expect(urls('HOMELAB')).toEqual(urls('homelab'));
+  });
+
+  it('ranks a title match above a tag match, and a tag match above a description', () => {
+    const posts = search(INDEX, 'homelab')[0];
+    expect(posts.results.map((r) => [r.entry.url, r.matchedIn])).toEqual([
+      ['/entries/https-for-your-homelab/', 'title'],
+      ['/entries/taming-ambiguity/', 'tag'],
+      ['/entries/dev-previews/', 'description'],
+    ]);
+  });
+
+  it('orders newest first inside one rank', () => {
+    const index = [post('DNS one', 'x', '2020-01-01'), post('DNS two', 'x', '2024-01-01')];
+    expect(search(index, 'dns')[0].results.map((r) => r.entry.url)).toEqual([
+      '/entries/dns-two/',
+      '/entries/dns-one/',
+    ]);
+  });
+
+  it('reports the term that matched', () => {
+    expect(search(INDEX, 'DNS')[0].results[0].term).toBe('DNS');
+  });
+
+  it('matches a tag by its label only', () => {
+    const tags = search(INDEX, 'leader').find((g) => g.label === 'TAGS');
+    expect(tags?.results.map((r) => r.entry.url)).toEqual(['/tags/leadership/']);
+  });
+
+  it('matches a page by label, title or description', () => {
+    expect(search(INDEX, 'src/').find((g) => g.label === 'PAGES')?.results).toHaveLength(1);
+    expect(search(INDEX, 'open sou').find((g) => g.label === 'PAGES')?.results).toHaveLength(1);
+    expect(search(INDEX, 'configs').find((g) => g.label === 'PAGES')?.results).toHaveLength(1);
+  });
+
+  it('caps posts at five, tags and pages at three, and still reports the true total', () => {
+    const many: Entry[] = [
+      ...Array.from({ length: 7 }, (_, i) => post(`dns post ${i}`, 'x', `202${i}-01-01`)),
+      ...Array.from({ length: 4 }, (_, i) => ({
+        kind: 'tag' as const, label: `dns${i}`, url: `/tags/dns${i}/`, count: i,
+      })),
+      ...Array.from({ length: 4 }, (_, i) => ({
+        kind: 'page' as const, label: `dns${i}/`, title: 'x', description: 'y', url: `/dns${i}/`,
+      })),
+    ];
+    const groups = search(many, 'dns');
+    expect(groups.map((g) => [g.label, g.results.length, g.total])).toEqual([
+      ['POSTS', 5, 7],
+      ['TAGS', 3, 4],
+      ['PAGES', 3, 4],
+    ]);
+  });
+
+  it('narrows to one group under a filter', () => {
+    expect(search(INDEX, 'homelab', 'tags').map((g) => g.label)).toEqual(['TAGS']);
+    expect(search(INDEX, 'homelab', 'posts').map((g) => g.label)).toEqual(['POSTS']);
+    expect(search(INDEX, 'homelab', 'pages').map((g) => g.label)).toEqual(['PAGES']);
+  });
+});
+
+describe('highlightParts', () => {
+  it('splits a string around every occurrence of the term', () => {
+    expect(highlightParts('dnsmasq and dns', 'dns')).toEqual([
+      { text: 'dns', hit: true },
+      { text: 'masq and ', hit: false },
+      { text: 'dns', hit: true },
+    ]);
+  });
+
+  it('keeps the casing of the source, not the query', () => {
+    expect(highlightParts('DNS lookups', 'dns')).toEqual([
+      { text: 'DNS', hit: true },
+      { text: ' lookups', hit: false },
+    ]);
+  });
+
+  it('returns one plain part when the term is absent or empty', () => {
+    expect(highlightParts('nothing here', 'dns')).toEqual([{ text: 'nothing here', hit: false }]);
+    expect(highlightParts('nothing here', '')).toEqual([{ text: 'nothing here', hit: false }]);
+  });
+});
+
+describe('postFilename', () => {
+  it('renders a post URL as the markdown file it came from', () => {
+    expect(postFilename('/entries/https-for-your-homelab/')).toBe('https-for-your-homelab.md');
+  });
+});
+
+describe('recentPosts', () => {
+  it('gives the three newest posts, newest first', () => {
+    expect(recentPosts(INDEX).map((p) => p.date)).toEqual(['2026-04-19', '2025-03-26', '2024-11-02']);
+  });
+});
+
+describe('topTags', () => {
+  it('gives the three highest-count tags', () => {
+    expect(topTags(INDEX).map((t) => t.label)).toEqual(['leadership', 'devops', 'homelab']);
+  });
+});


### PR DESCRIPTION
Adds the ⌘K command palette from `handoff-cmd-k`: search over the 30 posts, the 14 tags and the six
pages, drawn as a terminal window over the dimmed page. Mockups 4a, 4b and 4c.

## What it searches

Titles, descriptions and tag names. Post bodies are not indexed, which is the one deliberate
narrowing of the handoff: a reader of a personal blog searches by title, and leaving bodies out
keeps `/search-index.json` at 9.6 kB.

The index is a static file written at build time by `src/pages/search-index.json.ts`, fetched on
first open, prefetched on hover or focus of a trigger, and cached for the life of the page. No
search library: substring matching over this shape is enough, and a dependency here would be the
largest thing on the site.

Ranking is title, then tag, then description, newest first inside a rank. Groups cap at 5 posts,
3 tags and 3 pages, and the rule shows the true total. Each row says where it matched:
nothing for a title, `matched #devops` for a tag, `matched dev in summary` for a description.

## How it opens

Keyboard first. `⌘K` and `Ctrl+K` toggle, `/` opens when focus is outside a field, the arrow keys
walk one flat list across the group rules and wrap, `Tab` cycles all → posts → tags → pages,
`Enter` opens, `Backspace` on an empty query closes, `Esc` closes and hands focus back to the
trigger. Focus stays in the dialog because `Tab` never moves it.

Two visible ways in as well, since ⌘K means nothing on a phone: the `⌘K` cell at the end of the tab
strip, and `SEARCH` in the chrome bar under `md`. Both are server-rendered buttons carrying
`data-palette-open`; the island binds one delegated listener and remembers which one opened it.

## Two changes from the mockup

1. A selected row lifts its date and provenance from `--color-ink-muted` to
   `--color-ink-secondary`. Muted measures 4.45:1 against the selection wash, just under the floor,
   and axe over the open palette caught it. The wash and the 2px accent bar stay as drawn.
2. The chrome reads `bruno@bpaulino: ~ · search`. The mockup used an em dash, this project bans the
   character, and the middle dot is on the glyph allowlist.

Three smaller calls: the chips (JUMP TO pages, the tags on a miss) are arrow-reachable options,
because focus is trapped on the input and they would otherwise be keyboard-dead; the results pane
hides its scrollbar the way the tab strip does; and `N INDEXED` counts posts, the same number the
`grep:` error line reports.

## Also in here

- `src/lib/nav.ts` now holds the six destinations, so the tab strip, the mobile menu and the
  palette read one list instead of two.
- `/system` gets a live `CommandPalette` row with an `OPEN SEARCH` button.
- `theme.css` gains two values the palette alone uses: `--color-scrim` and `--color-line-palette`,
  the window line at 50%.
- `docs/design-system.md` §7.17 describes the component, and §14 no longer records the palette as
  dropped. `docs/verification.md` gains the palette pass. `CLAUDE.md` names the third island.

## Verification

- `npx vitest run`: 62 pass, including 17 for ranking, caps and provenance and 7 guarding the index
  shape and its size.
- `npx playwright test`: 305 pass, 45 of them new in `tests/e2e/palette.spec.ts`. That spec drives
  the whole keyboard contract with the mouse untouched, asserts the combobox and listbox state,
  checks 660px at 96px from the top on desktop and full screen with 44px rows at 390, and runs axe
  and the glyph audit over the open palette.
- `astro check`: clean.
- Compared against 4a, 4b and 4c by eye at 390, 768, 1024 and 1440.

## One cost

The palette is a React island on every page, so every page now pulls react-dom on idle: about 57 kB
gzipped, plus 4.7 kB for the palette. Before this, React only loaded on `/system`. The handoff chose
the island and struck the JS budget, so this follows it. The same behaviour as a vanilla TypeScript
island would drop the 57 kB and keep the markup identical, if that trade looks wrong later.
