### PR TITLE
feat: a hidden game behind the accent dot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/sitemap": "3.7.3",
         "@tailwindcss/vite": "4.3.3",
         "astro": "7.2.2",
+        "html2canvas": "^1.4.1",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "tailwindcss": "4.3.3",
@@ -3674,6 +3675,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
@@ -4215,6 +4225,15 @@
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -5069,6 +5088,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -7744,6 +7776,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -8193,6 +8234,15 @@
       "dependencies": {
         "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@astrojs/sitemap": "3.7.3",
     "@tailwindcss/vite": "4.3.3",
     "astro": "7.2.2",
+    "html2canvas": "^1.4.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "tailwindcss": "4.3.3",

--- a/src/components/chrome/InvadersShell.astro
+++ b/src/components/chrome/InvadersShell.astro
@@ -1,0 +1,171 @@
+---
+import Caret from '../shell/Caret.astro';
+
+/**
+ * The game's window, as an inert template. `src/lib/invaders/index.ts` clones it
+ * on first open and `view.ts` fills the field.
+ *
+ * A template rather than a hidden subtree: template content lives in its own
+ * DocumentFragment, so it stays out of the accessibility tree, out of
+ * `document.querySelectorAll`, and therefore out of the caret and glyph sweeps
+ * until the game is actually on screen.
+ */
+---
+
+<template id="invaders-template">
+  <div class="fixed inset-0 z-50 overflow-y-auto bg-surface-page" data-invaders-root>
+    <div class="mx-auto max-w-window p-[10px] sm:p-7">
+      <div class="relative border border-line-window bg-surface-window">
+        <div
+          class="flex items-center gap-3 border-b border-line-chrome bg-surface-chrome px-[14px] py-[9px]"
+        >
+          <div class="flex gap-1.5" aria-hidden="true">
+            <span class="block h-[9px] w-[9px] bg-surface-inert"></span>
+            <span class="block h-[9px] w-[9px] bg-surface-inert"></span>
+            <span class="block h-[9px] w-[9px] bg-ink"></span>
+          </div>
+          <span class="text-2xs tracking-chrome text-ink-muted">
+            bruno@bpaulino: ~/invaders — 132×48
+          </span>
+          <span class="ml-auto text-2xs tracking-chrome text-accent-lift">ESC EXIT</span>
+        </div>
+
+        <div
+          data-invaders-hud
+          class="flex items-center gap-[34px] border-b border-line-hairline bg-surface-tabbar px-5 py-[11px]"
+        >
+          <span class="text-2xs tracking-label text-ink-muted">
+            SCORE <span class="text-md text-ink" data-invaders-score>000000</span>
+          </span>
+          <span class="text-2xs tracking-label text-ink-muted">
+            HI <span class="text-md text-accent-lift" data-invaders-hi>000000</span>
+          </span>
+          <span class="text-2xs tracking-label text-ink-muted">
+            WAVE <span class="text-md text-ink" data-invaders-wave>01</span>
+          </span>
+          <span
+            class="ml-auto flex items-center gap-2.5 text-2xs tracking-label text-ink-muted"
+          >
+            LIVES
+            <span class="flex gap-[7px]" data-invaders-lives></span>
+          </span>
+        </div>
+
+        <!-- The background reads `--game-field` in invaders.css rather than a
+             `bg-surface-code` utility, so the token the handoff asks for is the
+             one the field actually uses instead of sitting declared and unused. -->
+        <div class="relative overflow-hidden" data-invaders-field data-frame="a">
+          <div class="invaders-scan" aria-hidden="true"></div>
+          <!--
+            The sprite layers are out of the accessibility tree: they are a
+            picture of a game, and a screen reader has nothing to do with 45
+            block-glyph sprites. The HUD and the panels above stay readable, and
+            `innerText` still reaches the sprites, so the glyph audit covers
+            them either way.
+          -->
+          <div data-invaders-formation aria-hidden="true"></div>
+          <div data-invaders-bunkers aria-hidden="true"></div>
+          <div data-invaders-bombs aria-hidden="true"></div>
+          <div data-invaders-shot aria-hidden="true" hidden></div>
+          <div data-invaders-player aria-hidden="true"></div>
+          <div class="absolute inset-x-0 h-px bg-line-window" data-invaders-ground></div>
+
+          <div
+            class="absolute inset-0 flex flex-col justify-center px-11"
+            data-invaders-panel="title"
+            hidden
+          >
+            <div class="text-2xs tracking-title text-accent-lift">B P A U L I N O . C O M</div>
+            <div class="mt-3.5 text-3xl">INVADERS</div>
+            <div class="mt-6.5 flex flex-col gap-2.75" data-invaders-score-table></div>
+            <div class="invaders-pulse mt-7.5 text-md text-accent-lift">PRESS SPACE TO START</div>
+            <div class="mt-2.5 text-2xs tracking-chrome text-ink-muted">
+              ESC RETURNS YOU TO ~/POSTS
+            </div>
+          </div>
+
+          <div
+            class="absolute inset-0 flex flex-col justify-center px-10"
+            data-invaders-panel="waveClear"
+            hidden
+          >
+            <div class="text-2xs tracking-section text-accent-lift" data-invaders-cleared></div>
+            <div class="mt-3 text-xl">
+              + <span data-invaders-bonus></span> <span class="text-ink-muted">pts</span>
+            </div>
+            <div class="mt-3 text-sm text-ink-muted">
+              <span data-invaders-next-wave></span><Caret />
+            </div>
+          </div>
+
+          <div
+            class="absolute inset-0 flex flex-col justify-center px-10"
+            data-invaders-panel="gameOver"
+            hidden
+          >
+            <div class="text-3xl tracking-label text-accent">GAME OVER</div>
+            <div class="mt-3.5 text-sm text-ink" data-invaders-death></div>
+            <div class="mt-1.5 text-sm text-ink-muted" data-invaders-exit></div>
+          </div>
+
+          <div
+            class="absolute inset-0 flex flex-col items-center justify-center"
+            data-invaders-panel="paused"
+            hidden
+          >
+            <div class="text-xl text-accent-lift">PAUSED</div>
+          </div>
+        </div>
+
+        <div
+          data-invaders-chrome-footer
+          class="border-t border-line-hairline bg-surface-tabbar px-5 py-2.5"
+        >
+          <div
+            class="flex gap-6 text-2xs tracking-chrome text-ink-muted"
+            data-invaders-footer="playing"
+          >
+            <span><span class="text-accent-lift">← →</span> MOVE</span>
+            <span><span class="text-accent-lift">SPACE</span> FIRE</span>
+            <span><span class="text-accent-lift">P</span> PAUSE</span>
+            <span class="ml-auto"><span class="text-accent-lift">ESC</span> BACK TO THE BLOG</span>
+          </div>
+          <div
+            class="flex gap-6 text-2xs tracking-chrome text-ink-muted"
+            data-invaders-footer="paused"
+            hidden
+          >
+            <span><span class="text-accent-lift">P</span> RESUME</span>
+            <span class="ml-auto"><span class="text-accent-lift">ESC</span> BACK TO THE BLOG</span>
+          </div>
+          <div
+            class="flex gap-6 text-2xs tracking-chrome text-ink-muted"
+            data-invaders-footer="gameOver"
+            hidden
+          >
+            <span><span class="text-accent-lift">SPACE</span> RETRY</span>
+            <span class="ml-auto"><span class="text-accent-lift">ESC</span> BACK TO THE BLOG</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style is:global>
+  /* The title screen's one pulse. It is the only animation the game adds, and
+     the global reduced-motion rule in theme.css already flattens it. */
+  @keyframes invaders-pulse {
+    0%,
+    100% {
+      opacity: 0.55;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+
+  .invaders-pulse {
+    animation: invaders-pulse 1.6s ease-in-out infinite;
+  }
+</style>

--- a/src/components/chrome/Window.astro
+++ b/src/components/chrome/Window.astro
@@ -1,6 +1,7 @@
 ---
 import NavSheet from './NavSheet.astro';
 import SearchTrigger from './SearchTrigger.astro';
+import Caret from '../shell/Caret.astro';
 
 /**
  * The frame every page lives in: chrome bar, tab strip and body.
@@ -16,22 +17,53 @@ const { title, dims, current } = Astro.props;
 
 <div class="relative border border-line-window bg-surface-window">
   <div
+    data-chrome
     class="flex items-center gap-[9px] border-b border-line-chrome bg-surface-chrome px-3 py-[9px] sm:gap-3 sm:px-[14px]"
   >
-    <div class="flex gap-[5px] sm:gap-1.5" aria-hidden="true">
+    <div class="flex gap-[5px] sm:gap-1.5">
       <span
+        aria-hidden="true"
         data-chrome-dot
-        class="hidden h-2 w-2 bg-surface-inert sm:block sm:h-[9px] sm:w-[9px]"
-      ></span>
-      <span data-chrome-dot class="block h-2 w-2 bg-surface-inert sm:h-[9px] sm:w-[9px]"></span>
-      <span data-chrome-dot class="block h-2 w-2 bg-accent sm:h-[9px] sm:w-[9px]"></span>
+        class="hidden h-2 w-2 bg-surface-inert sm:block sm:h-[9px] sm:w-[9px]"></span>
+      <span
+        aria-hidden="true"
+        data-chrome-dot
+        class="block h-2 w-2 bg-surface-inert sm:h-[9px] sm:w-[9px]"></span>
+      <!--
+        The third dot is the easter egg. Above 900px on a fine pointer it is a
+        real button; everywhere else it is the inert square it has always been.
+        Exactly one of the two renders, so the dot count and the chrome title
+        never move. Display is set in the style block below rather than by a
+        Tailwind utility: the two would have equal specificity and the winner
+        would come down to stylesheet order.
+      -->
+      <button
+        type="button"
+        aria-label="Play invaders"
+        data-invaders-open
+        data-chrome-dot
+        class="invaders-trigger h-2 w-2 bg-accent sm:h-[9px] sm:w-[9px]"></button>
+      <span
+        aria-hidden="true"
+        data-chrome-dot
+        class="invaders-dot h-2 w-2 bg-accent sm:h-[9px] sm:w-[9px]"></span>
     </div>
     <span class="text-2xs tracking-chrome text-ink-muted">
       {title}
       {dims && <span class="hidden md:inline"> — {dims}</span>}
     </span>
-    <div class="ml-auto hidden items-center gap-3 text-2xs tracking-chrome text-ink-muted md:flex">
+    <div
+      data-chrome-meta
+      class="ml-auto hidden items-center gap-3 text-2xs tracking-chrome text-ink-muted md:flex"
+    >
       <slot name="chrome-meta" />
+    </div>
+    <div
+      data-invaders-hint
+      aria-hidden="true"
+      class="ml-auto hidden items-center gap-1.75 text-2xs tracking-chrome text-accent-lift"
+    >
+      ./invaders<Caret size="xs" />
     </div>
     <div class="ml-auto flex items-center gap-3 md:hidden">
       <SearchTrigger variant="chrome" />
@@ -45,3 +77,75 @@ const { title, dims, current } = Astro.props;
     <slot />
   </div>
 </div>
+
+<style is:global>
+  /* Below 900px, or on a coarse pointer, the accent dot is the inert square and
+     the button is not rendered at all, so it cannot be focused either. */
+  .invaders-trigger {
+    display: none;
+    padding: 0;
+    border: 0;
+    appearance: none;
+    position: relative;
+  }
+
+  .invaders-dot {
+    display: block;
+  }
+
+  /* The hit area is 24 by 24 around a 9px square. A pseudo-element rather than
+     padding: padding would widen the layout box and shift the chrome title. */
+  .invaders-trigger::after {
+    content: '';
+    position: absolute;
+    inset: -7.5px;
+  }
+
+  /* At rest the hint is not rendered and its caret does not animate. That is
+     what keeps the one-animating-caret rule true on a page at rest. */
+  [data-invaders-hint] .caret {
+    animation: none;
+  }
+
+  @media (min-width: 900px) and (pointer: fine) {
+    .invaders-trigger {
+      display: block;
+      cursor: pointer;
+    }
+
+    .invaders-dot {
+      display: none;
+    }
+
+    /* A zero blur ring, not elevation. Both alphas the design asks for already
+       exist as line tokens, so this adds no colour. */
+    .invaders-trigger:hover {
+      box-shadow: 0 0 0 3px var(--color-line-chrome);
+    }
+
+    .invaders-trigger:active {
+      background: var(--color-ink);
+      box-shadow: 0 0 0 3px var(--color-line-palette);
+    }
+
+    /* Held white for as long as the game is open. */
+    .invaders-trigger[data-open] {
+      background: var(--color-ink);
+      box-shadow: none;
+    }
+
+    /* The button sits inside the dot group, so it is not a sibling of the meta
+       text. `:has()` is what lets the swap stay in CSS. */
+    [data-chrome]:has([data-invaders-open]:is(:hover, :focus-visible)) [data-chrome-meta] {
+      display: none;
+    }
+
+    [data-chrome]:has([data-invaders-open]:is(:hover, :focus-visible)) [data-invaders-hint] {
+      display: flex;
+    }
+
+    [data-chrome]:has([data-invaders-open]:is(:hover, :focus-visible)) [data-invaders-hint] .caret {
+      animation: var(--animate-blink);
+    }
+  }
+</style>

--- a/src/components/chrome/Window.astro
+++ b/src/components/chrome/Window.astro
@@ -119,7 +119,8 @@ const { title, dims, current } = Astro.props;
 
     /* A zero blur ring, not elevation. Both alphas the design asks for already
        exist as line tokens, so this adds no colour. */
-    .invaders-trigger:hover {
+    .invaders-trigger:hover,
+    .invaders-trigger:focus-visible {
       box-shadow: 0 0 0 3px var(--color-line-chrome);
     }
 

--- a/src/components/islands/CommandPalette.tsx
+++ b/src/components/islands/CommandPalette.tsx
@@ -56,6 +56,15 @@ function inField(target: EventTarget | null): boolean {
 }
 
 /**
+ * True while some other modal owns the keyboard. Only ever called while
+ * closed: the palette renders nothing then, so any dialog found belongs to
+ * someone else, and opening on top of it would strand the reader behind it.
+ */
+function otherModalOpen(): boolean {
+  return document.querySelector('[role="dialog"][aria-modal="true"]') !== null;
+}
+
+/**
  * The nearest matching element, or null. Guards the instance check because
  * `focusin` and `pointerenter` also fire with `document` as the target, which
  * has no `closest`.
@@ -181,11 +190,22 @@ export default function CommandPalette() {
       if (shortcut) {
         // ⌘K is the browser's own bookmark search on some platforms.
         event.preventDefault();
+        // Never open on top of another modal. The invaders overlay owns the
+        // keyboard while it is up, and a palette opening behind it strands the
+        // reader in a dialog they cannot see.
+        if (!open && otherModalOpen()) return;
         if (!open) triggerRef.current = restoreTarget();
         setOpen((was) => !was);
         return;
       }
-      if (!open && event.key === '/' && !inField(event.target) && !event.metaKey && !event.ctrlKey) {
+      if (
+        !open &&
+        event.key === '/' &&
+        !inField(event.target) &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !otherModalOpen()
+      ) {
         event.preventDefault();
         triggerRef.current = restoreTarget();
         setOpen(true);

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -145,5 +145,9 @@ const windowTitle = `bruno@bpaulino: ${shellPath ?? derivedShellPath}`;
         });
       });
     </script>
+    <script>
+      import { install } from '../lib/invaders';
+      install();
+    </script>
   </body>
 </html>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,6 +4,7 @@ import Scanlines from '../components/chrome/Scanlines.astro';
 import Window from '../components/chrome/Window.astro';
 import TabBar from '../components/chrome/TabBar.astro';
 import CommandPalette from '../components/islands/CommandPalette.tsx';
+import InvadersShell from '../components/chrome/InvadersShell.astro';
 
 /**
  * The shell every page renders inside: html head, page void, scanlines,
@@ -120,6 +121,7 @@ const windowTitle = `bruno@bpaulino: ${shellPath ?? derivedShellPath}`;
       </Window>
     </div>
     <CommandPalette client:idle />
+    <InvadersShell />
     <script>
       // Copy control for markdown-derived code blocks (src/lib/rehype-code-block.ts).
       // CodeBlock.astro's own copy button is a React island (see

--- a/src/lib/invaders/bunkers.ts
+++ b/src/lib/invaders/bunkers.ts
@@ -1,0 +1,69 @@
+import { cellAt, type Rect } from './collide';
+import { BUNKER, SPRITE_COLS, gridCells } from './sprites';
+import {
+  BUNKERS_W,
+  BUNKER_COUNT,
+  BUNKER_GAP,
+  BUNKER_H,
+  BUNKER_ROWS,
+  BUNKER_TOP,
+  CELL_W,
+} from './rules';
+
+export interface Bunker {
+  x: number;
+  /** Row major, `BUNKER_ROWS` by `SPRITE_COLS`. Erosion clears cells here. */
+  cells: boolean[][];
+}
+
+/** Four bunkers, 96px apart, as one group centred in the field. */
+export function createBunkers(fieldW: number): Bunker[] {
+  const left = (fieldW - BUNKERS_W) / 2;
+  return Array.from({ length: BUNKER_COUNT }, (_unused, i) => ({
+    x: left + i * (CELL_W + BUNKER_GAP),
+    cells: gridCells(BUNKER),
+  }));
+}
+
+export function bunkerRect(b: Bunker): Rect {
+  return { x: b.x, y: BUNKER_TOP, w: CELL_W, h: BUNKER_H };
+}
+
+/**
+ * Clears the 3x3 block of cells around the one a projectile landed in, and
+ * reports whether anything was there to hit.
+ *
+ * A projectile that reaches an already cleared cell is not a hit: it carries on
+ * through the gap. That is what makes a hole in a bunker worth shooting.
+ */
+export function erode(b: Bunker, px: number, py: number): boolean {
+  const cell = cellAt(bunkerRect(b), SPRITE_COLS, BUNKER_ROWS, px, py);
+  if (!cell) return false;
+  if (!b.cells[cell.row][cell.col]) return false;
+
+  // A 3x3 block, clipped to the grid. The design asks for four states and then
+  // gone, and a smaller mask cannot get there: clearing only the cell and its
+  // four neighbours leaves a checkerboard of six cells that no aim can finish.
+  for (let dr = -1; dr <= 1; dr += 1) {
+    for (let dc = -1; dc <= 1; dc += 1) {
+      const row = cell.row + dr;
+      const col = cell.col + dc;
+      if (row < 0 || row >= BUNKER_ROWS || col < 0 || col >= SPRITE_COLS) continue;
+      b.cells[row][col] = false;
+    }
+  }
+  return true;
+}
+
+export function isGone(b: Bunker): boolean {
+  return b.cells.every((row) => row.every((lit) => !lit));
+}
+
+export function litCells(b: Bunker): number {
+  return b.cells.flat().filter(Boolean).length;
+}
+
+/** The bunker as sprite rows, for `view.ts` to write into its `<pre>`. */
+export function bunkerRows(b: Bunker): string[] {
+  return b.cells.map((row) => row.map((lit) => (lit ? '█' : ' ')).join(''));
+}

--- a/src/lib/invaders/collide.ts
+++ b/src/lib/invaders/collide.ts
@@ -1,0 +1,31 @@
+/** Hit geometry. Pure, and unaware of what any box represents. */
+
+export interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** True when two boxes share area. Touching edges do not count. */
+export function overlaps(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+}
+
+/**
+ * The grid cell a point lands in, or null when the point is outside the box.
+ * Bunker erosion uses this to turn a bomb's position into a cell to clear.
+ */
+export function cellAt(
+  box: Rect,
+  cols: number,
+  rows: number,
+  px: number,
+  py: number
+): { col: number; row: number } | null {
+  if (px < box.x || px >= box.x + box.w) return null;
+  if (py < box.y || py >= box.y + box.h) return null;
+  const col = Math.min(cols - 1, Math.floor(((px - box.x) / box.w) * cols));
+  const row = Math.min(rows - 1, Math.floor(((py - box.y) / box.h) * rows));
+  return { col, row };
+}

--- a/src/lib/invaders/formation.ts
+++ b/src/lib/invaders/formation.ts
@@ -1,0 +1,137 @@
+import type { Rect } from './collide';
+import {
+  BURST_MS,
+  CELL_H,
+  CELL_W,
+  COLUMNS,
+  COLUMN_PITCH,
+  DESCENT,
+  RANKS,
+  RANK_PITCH,
+  SCORES,
+  STEP_X,
+  beatFloorFor,
+  beatFor,
+  formationLeftFor,
+  formationTopFor,
+} from './rules';
+
+export interface Invader {
+  /** 0 is the top rank, worth 30. 4 is the bottom, worth 10. */
+  rank: number;
+  col: number;
+  alive: boolean;
+  /** While this is in the future the burst sprite shows in the invader's place. */
+  burstUntil: number;
+}
+
+export interface Formation {
+  left: number;
+  top: number;
+  dir: 1 | -1;
+  frame: 'a' | 'b';
+  invaders: Invader[];
+  kills: number;
+  nextBeatAt: number;
+  beatFloor: number;
+}
+
+export function createFormation(wave: number, fieldW: number, now: number): Formation {
+  const invaders: Invader[] = [];
+  for (let rank = 0; rank < RANKS; rank += 1) {
+    for (let col = 0; col < COLUMNS; col += 1) {
+      invaders.push({ rank, col, alive: true, burstUntil: 0 });
+    }
+  }
+  const beatFloor = beatFloorFor(wave);
+  return {
+    left: formationLeftFor(fieldW),
+    top: formationTopFor(wave),
+    dir: 1,
+    frame: 'a',
+    invaders,
+    kills: 0,
+    nextBeatAt: now + beatFor(0, beatFloor),
+    beatFloor,
+  };
+}
+
+export function invaderRect(f: Formation, inv: Invader): Rect {
+  return {
+    x: f.left + inv.col * COLUMN_PITCH,
+    y: f.top + inv.rank * RANK_PITCH,
+    w: CELL_W,
+    h: CELL_H,
+  };
+}
+
+export function alive(f: Formation): Invader[] {
+  return f.invaders.filter((inv) => inv.alive);
+}
+
+export function occupiedColumns(f: Formation): number[] {
+  return [...new Set(alive(f).map((inv) => inv.col))].sort((a, b) => a - b);
+}
+
+/** The living invader nearest the player in `col`, which is the one that bombs. */
+export function lowestInColumn(f: Formation, col: number): Invader | null {
+  let found: Invader | null = null;
+  for (const inv of f.invaders) {
+    if (!inv.alive || inv.col !== col) continue;
+    if (!found || inv.rank > found.rank) found = inv;
+  }
+  return found;
+}
+
+/** The bottom edge of the lowest living rank. Reaching the ground ends the game. */
+export function formationBottom(f: Formation): number {
+  const living = alive(f);
+  if (living.length === 0) return f.top;
+  const lowest = Math.max(...living.map((inv) => inv.rank));
+  return f.top + lowest * RANK_PITCH + CELL_H;
+}
+
+/**
+ * Advances the block if its beat is due. Returns true when a step happened, so
+ * the caller knows a beat has passed and can drop a bomb on it.
+ *
+ * A step is either a horizontal jump or a descent, never both: touching a wall
+ * spends the beat on the drop.
+ */
+export function stepFormation(f: Formation, now: number, fieldW: number): boolean {
+  if (now < f.nextBeatAt) return false;
+
+  f.frame = f.frame === 'a' ? 'b' : 'a';
+
+  const living = alive(f);
+  if (living.length > 0) {
+    const cols = living.map((inv) => inv.col);
+    const nextLeft = f.left + f.dir * STEP_X;
+    const edgeLeft = nextLeft + Math.min(...cols) * COLUMN_PITCH;
+    const edgeRight = nextLeft + Math.max(...cols) * COLUMN_PITCH + CELL_W;
+
+    if (edgeLeft < 0 || edgeRight > fieldW) {
+      f.top += DESCENT;
+      f.dir = f.dir === 1 ? -1 : 1;
+    } else {
+      f.left = nextLeft;
+    }
+  }
+
+  f.nextBeatAt = now + beatFor(f.kills, f.beatFloor);
+  return true;
+}
+
+/** Kills an invader and returns the points it was worth. */
+export function killInvader(f: Formation, inv: Invader, now: number): number {
+  inv.alive = false;
+  inv.burstUntil = now + BURST_MS;
+  f.kills += 1;
+  return SCORES[inv.rank];
+}
+
+export function clearBursts(f: Formation, now: number): void {
+  for (const inv of f.invaders) {
+    if (inv.burstUntil !== 0 && now >= inv.burstUntil) inv.burstUntil = 0;
+  }
+}

--- a/src/lib/invaders/game.ts
+++ b/src/lib/invaders/game.ts
@@ -40,6 +40,14 @@ function mount(): HTMLElement {
 }
 
 function onKeyDown(event: KeyboardEvent): void {
+  // The root claims aria-modal and nothing inside the window is focusable, so
+  // Tab has nowhere to go. Without this it walks into the page behind the
+  // overlay, which is still interactive.
+  if (event.key === 'Tab') {
+    event.preventDefault();
+    return;
+  }
+
   if (event.key !== 'Escape') return;
   event.preventDefault();
   closeGame();
@@ -48,13 +56,16 @@ function onKeyDown(event: KeyboardEvent): void {
 export async function openGame(): Promise<void> {
   if (root) return;
 
+  // Mount before anything else. Every line below changes the page, and mount can
+  // throw: locking the scroll first would leave the reader stuck with no way back.
+  const mounted = mount();
+
   trigger = document.querySelector<HTMLElement>('[data-invaders-open]');
   trigger?.setAttribute('data-open', '');
-
   restoreScroll = window.scrollY;
   document.body.style.overflow = 'hidden';
 
-  root = mount();
+  root = mounted;
   root.focus();
   window.addEventListener('keydown', onKeyDown);
 }

--- a/src/lib/invaders/game.ts
+++ b/src/lib/invaders/game.ts
@@ -85,7 +85,7 @@ function onKeyDown(event: KeyboardEvent): void {
   switch (event.key) {
     case 'Escape':
       event.preventDefault();
-      closeGame();
+      void closeGame();
       return;
     case 'Tab':
       // The root claims aria-modal and nothing inside the window is focusable,
@@ -148,6 +148,9 @@ export async function openGame(): Promise<void> {
   restoreScroll = window.scrollY;
   document.body.style.overflow = 'hidden';
 
+  // The game mounts before the transition runs. That is how the transition
+  // learns where the field will be, so the invaders it draws at 520ms land
+  // exactly where the real ones appear at 720ms.
   root = mounted;
   refs = collect(root);
   savedHi = readHiScore();
@@ -155,8 +158,11 @@ export async function openGame(): Promise<void> {
   builtWave = state.wave;
   build(refs, state);
   render(refs, state);
-  root.focus();
 
+  const { run } = await import('./transition');
+  await run(refs.field.getBoundingClientRect(), 'in');
+
+  root.focus();
   held.left = false;
   held.right = false;
   fireQueued = false;
@@ -168,8 +174,8 @@ export async function openGame(): Promise<void> {
   frame = requestAnimationFrame(tick);
 }
 
-export function closeGame(): void {
-  if (!root) return;
+export async function closeGame(): Promise<void> {
+  if (!root || !refs) return;
 
   cancelAnimationFrame(frame);
   window.removeEventListener('keydown', onKeyDown);
@@ -177,6 +183,9 @@ export function closeGame(): void {
   window.removeEventListener('resize', onResize);
 
   if (state && state.hi > savedHi) writeHiScore(state.hi);
+
+  const { run } = await import('./transition');
+  await run(refs.field.getBoundingClientRect(), 'out');
 
   root.remove();
   root = null;

--- a/src/lib/invaders/game.ts
+++ b/src/lib/invaders/game.ts
@@ -1,17 +1,30 @@
-import { HI_SCORE_KEY } from './rules';
+import { HI_SCORE_KEY, clampPlayerX } from './rules';
+import { createGame, startGame, step, togglePause, type GameState, type Input } from './state';
+import { build, collect, render, type Refs } from './view';
 
 /**
- * The game's lifecycle: mount the template, lock the page, hand back the exact
- * scroll position on the way out.
+ * The game's lifecycle and its loop. The loop reads input, steps the pure state
+ * machine, and hands the result to the view. It decides nothing.
  */
 
+/** A backgrounded tab hands back a huge delta. Capping it stops the block teleporting. */
+const MAX_FRAME_MS = 50;
+
 let root: HTMLElement | null = null;
+let refs: Refs | null = null;
+let state: GameState | null = null;
 let trigger: HTMLElement | null = null;
+let frame = 0;
+let lastFrameAt = 0;
+let builtWave = 0;
+let savedHi = 0;
 let restoreScroll = 0;
 
+const held = { left: false, right: false };
+let fireQueued = false;
+
 export function readHiScore(): number {
-  const raw = window.localStorage.getItem(HI_SCORE_KEY);
-  const value = Number.parseInt(raw ?? '', 10);
+  const value = Number.parseInt(window.localStorage.getItem(HI_SCORE_KEY) ?? '', 10);
   return Number.isFinite(value) && value > 0 ? value : 0;
 }
 
@@ -19,8 +32,8 @@ export function writeHiScore(hi: number): void {
   try {
     window.localStorage.setItem(HI_SCORE_KEY, String(hi));
   } catch {
-    // Private browsing refuses the write. The run still counts, it just does
-    // not outlive the tab, and losing a hi score is not worth an error.
+    // Private browsing refuses the write. The run still counts, it just does not
+    // outlive the tab, and a lost hi score is not worth an error.
   }
 }
 
@@ -39,25 +52,95 @@ function mount(): HTMLElement {
   return el;
 }
 
-function onKeyDown(event: KeyboardEvent): void {
-  // The root claims aria-modal and nothing inside the window is focusable, so
-  // Tab has nowhere to go. Without this it walks into the page behind the
-  // overlay, which is still interactive.
-  if (event.key === 'Tab') {
-    event.preventDefault();
-    return;
+function tick(now: number): void {
+  frame = requestAnimationFrame(tick);
+  if (!state || !refs) return;
+
+  const dt = Math.min(MAX_FRAME_MS, now - lastFrameAt);
+  lastFrameAt = now;
+
+  const input: Input = { left: held.left, right: held.right, fire: fireQueued };
+  fireQueued = false;
+
+  step(state, dt, input, Math.random);
+
+  // A new wave replaces the formation and the bunkers, so the DOM has to be
+  // rebuilt before it is read.
+  if (state.wave !== builtWave) {
+    builtWave = state.wave;
+    build(refs, state);
   }
 
-  if (event.key !== 'Escape') return;
-  event.preventDefault();
-  closeGame();
+  render(refs, state);
+
+  if (state.hi > savedHi) {
+    savedHi = state.hi;
+    writeHiScore(savedHi);
+  }
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (!state) return;
+
+  switch (event.key) {
+    case 'Escape':
+      event.preventDefault();
+      closeGame();
+      return;
+    case 'Tab':
+      // The root claims aria-modal and nothing inside the window is focusable,
+      // so Tab has nowhere to go. Without this it walks into the page behind the
+      // overlay, which is still interactive.
+      event.preventDefault();
+      return;
+    case 'ArrowLeft':
+      event.preventDefault();
+      held.left = true;
+      return;
+    case 'ArrowRight':
+      event.preventDefault();
+      held.right = true;
+      return;
+    case ' ':
+      event.preventDefault();
+      // Tap to fire. The browser repeats keydown while a key is held, and
+      // letting that through would be autofire.
+      if (event.repeat) return;
+      if (state.phase === 'title' || state.phase === 'gameOver') {
+        startGame(state);
+        // Forces the rebuild in the next tick: startGame makes a fresh
+        // formation, and the old elements describe the old one.
+        builtWave = 0;
+        return;
+      }
+      fireQueued = true;
+      return;
+    case 'p':
+    case 'P':
+      event.preventDefault();
+      togglePause(state);
+      return;
+  }
+}
+
+function onKeyUp(event: KeyboardEvent): void {
+  if (event.key === 'ArrowLeft') held.left = false;
+  if (event.key === 'ArrowRight') held.right = false;
+}
+
+/** The field is fluid, so a resize changes where the walls are. */
+function onResize(): void {
+  if (!state || !refs) return;
+  state.fieldW = refs.field.clientWidth;
+  state.playerX = clampPlayerX(state.playerX, state.fieldW);
 }
 
 export async function openGame(): Promise<void> {
   if (root) return;
 
   // Mount before anything else. Every line below changes the page, and mount can
-  // throw: locking the scroll first would leave the reader stuck with no way back.
+  // throw: committing the scroll lock first would leave the reader on a locked
+  // page with no Escape listener and no way back short of a reload.
   const mounted = mount();
 
   trigger = document.querySelector<HTMLElement>('[data-invaders-open]');
@@ -66,23 +149,46 @@ export async function openGame(): Promise<void> {
   document.body.style.overflow = 'hidden';
 
   root = mounted;
+  refs = collect(root);
+  savedHi = readHiScore();
+  state = createGame(savedHi, refs.field.clientWidth);
+  builtWave = state.wave;
+  build(refs, state);
+  render(refs, state);
   root.focus();
+
+  held.left = false;
+  held.right = false;
+  fireQueued = false;
+  lastFrameAt = performance.now();
+
   window.addEventListener('keydown', onKeyDown);
+  window.addEventListener('keyup', onKeyUp);
+  window.addEventListener('resize', onResize);
+  frame = requestAnimationFrame(tick);
 }
 
 export function closeGame(): void {
   if (!root) return;
 
+  cancelAnimationFrame(frame);
   window.removeEventListener('keydown', onKeyDown);
+  window.removeEventListener('keyup', onKeyUp);
+  window.removeEventListener('resize', onResize);
+
+  if (state && state.hi > savedHi) writeHiScore(state.hi);
+
   root.remove();
   root = null;
+  refs = null;
+  state = null;
 
   document.body.style.overflow = '';
   window.scrollTo(0, restoreScroll);
 
   trigger?.removeAttribute('data-open');
-  // A plain focus() scrolls the trigger into view if it sits off screen,
-  // which would undo the scrollTo above on a deep page.
+  // preventScroll matters: focusing the trigger scrolls it back into view, which
+  // lands the reader at the top of the page and undoes the restore above.
   trigger?.focus({ preventScroll: true });
   trigger = null;
 }

--- a/src/lib/invaders/game.ts
+++ b/src/lib/invaders/game.ts
@@ -1,0 +1,77 @@
+import { HI_SCORE_KEY } from './rules';
+
+/**
+ * The game's lifecycle: mount the template, lock the page, hand back the exact
+ * scroll position on the way out.
+ */
+
+let root: HTMLElement | null = null;
+let trigger: HTMLElement | null = null;
+let restoreScroll = 0;
+
+export function readHiScore(): number {
+  const raw = window.localStorage.getItem(HI_SCORE_KEY);
+  const value = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+export function writeHiScore(hi: number): void {
+  try {
+    window.localStorage.setItem(HI_SCORE_KEY, String(hi));
+  } catch {
+    // Private browsing refuses the write. The run still counts, it just does
+    // not outlive the tab, and losing a hi score is not worth an error.
+  }
+}
+
+function mount(): HTMLElement {
+  const template = document.querySelector<HTMLTemplateElement>('#invaders-template');
+  if (!template) throw new Error('invaders: the shell template is missing');
+  const fragment = template.content.cloneNode(true) as DocumentFragment;
+  const el = fragment.querySelector<HTMLElement>('[data-invaders-root]');
+  if (!el) throw new Error('invaders: the shell template has no root');
+
+  el.setAttribute('role', 'dialog');
+  el.setAttribute('aria-modal', 'true');
+  el.setAttribute('aria-label', 'Invaders');
+  el.tabIndex = -1;
+  document.body.append(el);
+  return el;
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (event.key !== 'Escape') return;
+  event.preventDefault();
+  closeGame();
+}
+
+export async function openGame(): Promise<void> {
+  if (root) return;
+
+  trigger = document.querySelector<HTMLElement>('[data-invaders-open]');
+  trigger?.setAttribute('data-open', '');
+
+  restoreScroll = window.scrollY;
+  document.body.style.overflow = 'hidden';
+
+  root = mount();
+  root.focus();
+  window.addEventListener('keydown', onKeyDown);
+}
+
+export function closeGame(): void {
+  if (!root) return;
+
+  window.removeEventListener('keydown', onKeyDown);
+  root.remove();
+  root = null;
+
+  document.body.style.overflow = '';
+  window.scrollTo(0, restoreScroll);
+
+  trigger?.removeAttribute('data-open');
+  // A plain focus() scrolls the trigger into view if it sits off screen,
+  // which would undo the scrollTo above on a deep page.
+  trigger?.focus({ preventScroll: true });
+  trigger = null;
+}

--- a/src/lib/invaders/game.ts
+++ b/src/lib/invaders/game.ts
@@ -159,8 +159,15 @@ export async function openGame(): Promise<void> {
   build(refs, state);
   render(refs, state);
 
-  const { run } = await import('./transition');
-  await run(refs.field.getBoundingClientRect(), 'in');
+  try {
+    const { run } = await import('./transition');
+    await run(refs.field.getBoundingClientRect(), 'in');
+  } catch (error) {
+    // The transition is decoration. If its chunk will not load, open the game
+    // without it: the alternative is a reader stranded on a scroll-locked page
+    // with the modal up and no input wired yet.
+    console.warn('invaders: transition unavailable', error);
+  }
 
   root.focus();
   held.left = false;
@@ -189,8 +196,15 @@ export async function closeGame(): Promise<void> {
 
   if (state && state.hi > savedHi) writeHiScore(state.hi);
 
-  const { run } = await import('./transition');
-  await run(refs.field.getBoundingClientRect(), 'out');
+  try {
+    const { run } = await import('./transition');
+    await run(refs.field.getBoundingClientRect(), 'out');
+  } catch (error) {
+    // Same reasoning as openGame, and it matters more here: the keydown listener
+    // is already gone, so a throw would leave the page locked with the modal up
+    // and Escape no longer doing anything.
+    console.warn('invaders: exit transition unavailable', error);
+  }
 
   root.remove();
   root = null;

--- a/src/lib/invaders/game.ts
+++ b/src/lib/invaders/game.ts
@@ -172,6 +172,11 @@ export async function openGame(): Promise<void> {
   window.addEventListener('keyup', onKeyUp);
   window.addEventListener('resize', onResize);
   frame = requestAnimationFrame(tick);
+
+  // The design arms input at 720ms, after the transition. Anything waiting on the
+  // game needs a signal for that moment: before it, a keypress has nothing
+  // listening for it. The window being on screen is not the same as being ready.
+  root.dataset.armed = '';
 }
 
 export async function closeGame(): Promise<void> {

--- a/src/lib/invaders/index.ts
+++ b/src/lib/invaders/index.ts
@@ -37,8 +37,14 @@ function modalOpen(): boolean {
 }
 
 async function launch(): Promise<void> {
-  const { openGame } = await import('./game');
-  await openGame();
+  try {
+    const { openGame } = await import('./game');
+    await openGame();
+  } catch (error) {
+    // A chunk that will not load is not worth breaking the page over. The reader
+    // came here to read, so leave everything exactly as they found it.
+    console.warn('invaders: could not start', error);
+  }
 }
 
 export function install(): void {
@@ -54,9 +60,13 @@ export function install(): void {
   document.addEventListener(
     'pointerenter',
     (event) => {
+      if (!desktop()) return;
       const target = event.target;
       if (!(target instanceof Element) || !target.closest('[data-invaders-open]')) return;
-      void import('./transition').then((mod) => mod.prepare());
+      // A failed prefetch is only a missed warm-up, never worth surfacing.
+      void import('./transition')
+        .then((mod) => mod.prepare())
+        .catch(() => {});
     },
     true
   );

--- a/src/lib/invaders/index.ts
+++ b/src/lib/invaders/index.ts
@@ -1,0 +1,79 @@
+import { DESKTOP_QUERY } from './rules';
+
+/**
+ * The only part of the game that loads on every page: a media query, two
+ * listeners, and a dynamic import. The state machine, the view and the
+ * rasteriser all sit behind that import, so a reader who never opens the game
+ * downloads none of them.
+ */
+
+const SEQUENCE = 'inv';
+/** The sequence is undocumented, so it resets quickly rather than lingering. */
+const SEQUENCE_IDLE_MS = 1000;
+
+let typed = '';
+let lastKeyAt = 0;
+
+/**
+ * Read live rather than cached, so a reader who resizes past the trigger's
+ * breakpoint gets a working listener behind it, not a button with nothing
+ * wired to it.
+ */
+function desktop(): boolean {
+  return window.matchMedia(DESKTOP_QUERY).matches;
+}
+
+/** True when the keystroke belongs to whatever the reader is typing in. */
+function inField(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    target.closest('input, textarea, select, [contenteditable]') !== null
+  );
+}
+
+/** True while any modal owns the keyboard, the palette included. */
+function modalOpen(): boolean {
+  return document.querySelector('[role="dialog"][aria-modal="true"]') !== null;
+}
+
+async function launch(): Promise<void> {
+  const { openGame } = await import('./game');
+  await openGame();
+}
+
+export function install(): void {
+  document.addEventListener('click', (event) => {
+    if (!desktop()) return;
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (!target.closest('[data-invaders-open]')) return;
+    void launch();
+  });
+
+  // Warms the rasteriser before the click, so the click itself feels instant.
+  document.addEventListener(
+    'pointerenter',
+    (event) => {
+      const target = event.target;
+      if (!(target instanceof Element) || !target.closest('[data-invaders-open]')) return;
+      void import('./transition').then((mod) => mod.prepare());
+    },
+    true
+  );
+
+  window.addEventListener('keydown', (event) => {
+    if (!desktop()) return;
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+    if (inField(event.target) || modalOpen()) return;
+
+    const now = event.timeStamp;
+    if (now - lastKeyAt > SEQUENCE_IDLE_MS) typed = '';
+    lastKeyAt = now;
+
+    typed = (typed + event.key.toLowerCase()).slice(-SEQUENCE.length);
+    if (typed !== SEQUENCE) return;
+
+    typed = '';
+    void launch();
+  });
+}

--- a/src/lib/invaders/projectiles.ts
+++ b/src/lib/invaders/projectiles.ts
@@ -1,0 +1,39 @@
+import type { Rect } from './collide';
+import { BOMB_H, BOMB_SPEED, BOMB_W, FIELD_H, SHOT_H, SHOT_SPEED, SHOT_W } from './rules';
+
+/** `x` and `y` are the top left corner, so only the rect helpers know the size. */
+export interface Shot {
+  x: number;
+  y: number;
+}
+
+export interface Bomb {
+  x: number;
+  y: number;
+  /** The rank that dropped it, which the game over line reports. */
+  rank: number;
+}
+
+export function shotRect(shot: Shot): Rect {
+  return { x: shot.x, y: shot.y, w: SHOT_W, h: SHOT_H };
+}
+
+export function bombRect(bomb: Bomb): Rect {
+  return { x: bomb.x, y: bomb.y, w: BOMB_W, h: BOMB_H };
+}
+
+/** The shot after `dt` milliseconds, or null once it has left the field. */
+export function advanceShot(shot: Shot | null, dt: number): Shot | null {
+  if (!shot) return null;
+  const y = shot.y - (SHOT_SPEED * dt) / 1000;
+  if (y + SHOT_H <= 0) return null;
+  return { x: shot.x, y };
+}
+
+/** Every bomb after `dt` milliseconds, minus the ones past the bottom. */
+export function advanceBombs(bombs: Bomb[], dt: number): Bomb[] {
+  const fall = (BOMB_SPEED * dt) / 1000;
+  return bombs
+    .map((bomb) => ({ x: bomb.x, y: bomb.y + fall, rank: bomb.rank }))
+    .filter((bomb) => bomb.y < FIELD_H);
+}

--- a/src/lib/invaders/rules.ts
+++ b/src/lib/invaders/rules.ts
@@ -1,5 +1,3 @@
-import { SPRITE_COLS } from './sprites';
-
 /**
  * Every number the design measured, and the four that derive from them.
  *
@@ -13,6 +11,9 @@ import { SPRITE_COLS } from './sprites';
 
 export const RANKS = 5;
 export const COLUMNS = 9;
+
+/** A sprite grid is seven cells wide. */
+export const SPRITE_COLS = 7;
 
 /** A sprite cell at `font-size: 13px` and `line-height: .72`. */
 export const CELL_W = 57.9;

--- a/src/lib/invaders/rules.ts
+++ b/src/lib/invaders/rules.ts
@@ -1,0 +1,145 @@
+import { SPRITE_COLS } from './sprites';
+
+/**
+ * Every number the design measured, and the four that derive from them.
+ *
+ * These are game metrics, not design tokens. None of them sits on the 11 and
+ * 5.5 pixel grid, and none belongs in `theme.css`. `view.ts` writes them onto
+ * the field as CSS custom properties, which is why no Tailwind utility on the
+ * field ever carries an arbitrary value.
+ */
+
+// ---- the formation ---------------------------------------------------------
+
+export const RANKS = 5;
+export const COLUMNS = 9;
+
+/** A sprite cell at `font-size: 13px` and `line-height: .72`. */
+export const CELL_W = 57.9;
+export const CELL_H = 46.8;
+
+/** One sprite row. Five of them make a 46.8px invader. */
+export const ROW_H = CELL_H / RANKS;
+
+export const COLUMN_PITCH = 77.9;
+export const RANK_PITCH = 61.8;
+
+export const FORMATION_W = (COLUMNS - 1) * COLUMN_PITCH + CELL_W;
+export const FORMATION_H = (RANKS - 1) * RANK_PITCH + CELL_H;
+
+/** Wave one, which the handoff measures as occupying y 26 to 320. */
+export const FORMATION_TOP = 26;
+
+/** One glyph cell. The block jumps this far on every beat, with no tween. */
+export const STEP_X = CELL_W / SPRITE_COLS;
+
+/** On touching either wall the block drops this far and reverses. No easing. */
+export const DESCENT = 16;
+
+// ---- the field -------------------------------------------------------------
+
+export const FIELD_H = 466;
+
+export const GROUND_FROM_BOTTOM = 24;
+export const GROUND_Y = FIELD_H - GROUND_FROM_BOTTOM;
+
+export const BUNKER_COUNT = 4;
+export const BUNKER_TOP = 352;
+export const BUNKER_GAP = 96;
+export const BUNKER_ROWS = 4;
+export const BUNKER_H = ROW_H * BUNKER_ROWS;
+/** Four bunkers with 96px between them, taken as one centred group. */
+export const BUNKERS_W = BUNKER_COUNT * CELL_W + (BUNKER_COUNT - 1) * BUNKER_GAP;
+
+export const PLAYER_ROWS = 4;
+export const PLAYER_H = ROW_H * PLAYER_ROWS;
+export const PLAYER_FROM_BOTTOM = 34;
+export const PLAYER_TOP = FIELD_H - PLAYER_FROM_BOTTOM - PLAYER_H;
+
+// ---- speeds and timings ----------------------------------------------------
+
+export const PLAYER_SPEED = 380; // px per second, the only smooth motion
+export const SHOT_SPEED = 620;
+export const BOMB_SPEED = 210;
+
+export const SHOT_W = 3;
+export const SHOT_H = 19;
+export const BOMB_W = 3;
+export const BOMB_H = 15;
+export const MAX_BOMBS = 3;
+
+/**
+ * The opening beat. `--game-beat` in theme.css carries the same value as the
+ * design system's record of it. The runtime reads this one, so the audit in
+ * `tests/e2e/invaders.spec.ts` fails if the two ever drift apart.
+ */
+export const BEAT_START = 620;
+export const BEAT_DECAY = 0.94;
+export const BEAT_FLOOR = 90;
+
+/** The chance a beat drops a bomb, when fewer than three are already falling. */
+export const BOMB_CHANCE = 0.35;
+
+export const BURST_MS = 110;
+export const HIT_FLASH_MS = 60;
+export const RESPAWN_MS = 900;
+export const WAVE_CLEAR_MS = 2000;
+
+export const LIVES = 3;
+export const SCORES: readonly number[] = [30, 20, 20, 10, 10];
+
+// ---- sprite metrics the DOM needs -----------------------------------------
+
+export const SPRITE_PX = 13;
+export const LIVES_SPRITE_PX = 7;
+export const SPRITE_LINE_HEIGHT = 0.72;
+
+export const HI_SCORE_KEY = 'bpaulino:invaders:hi';
+
+/** The trigger, the game and the `i n v` route all sit behind this. */
+export const DESKTOP_QUERY = '(min-width: 900px) and (pointer: fine)';
+
+// ---- derived ---------------------------------------------------------------
+
+/**
+ * The beat after `kills` invaders have died, in milliseconds.
+ */
+export function beatFor(kills: number, floor: number = BEAT_FLOOR): number {
+  return Math.max(floor, BEAT_START * BEAT_DECAY ** kills);
+}
+
+/**
+ * The beat floor for a wave. Later waves get a lower one, which is what makes
+ * them harder once the formation can no longer start any lower.
+ */
+export function beatFloorFor(wave: number): number {
+  return Math.max(50, BEAT_FLOOR - (wave - 1) * 10);
+}
+
+/**
+ * The formation's top for a wave.
+ *
+ * The design asks each wave to start one rank lower. Only one wave of drop
+ * fits: the field is 466px, the formation is 294px, and that leaves 74.56px
+ * above the player against a rank pitch of 61.8px. Waves past the second start
+ * where the second does and take their difficulty from the beat floor instead.
+ */
+export function formationTopFor(wave: number): number {
+  return FORMATION_TOP + Math.min(wave - 1, 1) * RANK_PITCH;
+}
+
+/**
+ * The formation's left edge in a field of `fieldW`.
+ *
+ * The field is fluid: it is the window's inner width, which runs from 842px at
+ * the 900px trigger floor to 1042px at `max-w-window`. The formation is centred
+ * in it, which is what the handoff's origin of 180.4 at 1042px describes.
+ */
+export function formationLeftFor(fieldW: number): number {
+  return (fieldW - FORMATION_W) / 2;
+}
+
+/** `x` held so the whole cannon stays on the field. */
+export function clampPlayerX(x: number, fieldW: number): number {
+  return Math.min(Math.max(x, 0), fieldW - CELL_W);
+}

--- a/src/lib/invaders/rules.ts
+++ b/src/lib/invaders/rules.ts
@@ -97,6 +97,10 @@ export const SPRITE_PX = 13;
 export const LIVES_SPRITE_PX = 7;
 export const SPRITE_LINE_HEIGHT = 0.72;
 
+/** The title screen's score table draws its sprites smaller, in a fixed column. */
+export const SCORE_TABLE_SPRITE_PX = 11;
+export const SCORE_TABLE_SPRITE_W = 60;
+
 export const HI_SCORE_KEY = 'bpaulino:invaders:hi';
 
 /** The trigger, the game and the `i n v` route all sit behind this. */

--- a/src/lib/invaders/rules.ts
+++ b/src/lib/invaders/rules.ts
@@ -88,6 +88,9 @@ export const WAVE_CLEAR_MS = 2000;
 export const LIVES = 3;
 export const SCORES: readonly number[] = [30, 20, 20, 10, 10];
 
+/** Paid on clearing a wave, times the wave number. 160 x 3 is the mock's + 480. */
+export const WAVE_BONUS = 160;
+
 // ---- sprite metrics the DOM needs -----------------------------------------
 
 export const SPRITE_PX = 13;

--- a/src/lib/invaders/sprites.ts
+++ b/src/lib/invaders/sprites.ts
@@ -1,0 +1,57 @@
+/**
+ * The art. Every sprite is a grid of rows, seven cells wide, drawn in
+ * Departure Mono block glyphs.
+ *
+ * These grids are the art rather than a description of it. The transition draws
+ * the same cells to a canvas at 520ms, which is why they are data and not
+ * markup.
+ */
+
+export type Grid = readonly string[];
+export type SpritePair = { readonly a: Grid; readonly b: Grid };
+
+export const SPRITE_COLS = 7;
+
+/** Rank 1, 30 points. The bottom row alternates. */
+export const SQUID: SpritePair = {
+  a: ['  ███  ', ' █████ ', '███████', '█ ███ █', '  █ █  '],
+  b: ['  ███  ', ' █████ ', '███████', '█ ███ █', ' █   █ '],
+};
+
+/** Ranks 2 and 3, 20 points. Antennae and legs swap together. */
+export const CRAB: SpritePair = {
+  a: ['█     █', ' █████ ', '██ █ ██', '███████', ' █   █ '],
+  b: [' █   █ ', ' █████ ', '██ █ ██', '███████', '█     █'],
+};
+
+/** Ranks 4 and 5, 10 points. The bottom row alternates. */
+export const OCTOPUS: SpritePair = {
+  a: [' █████ ', '███████', '█ ███ █', '  ███  ', ' █   █ '],
+  b: [' █████ ', '███████', '█ ███ █', '  ███  ', '█     █'],
+};
+
+/** Shown for 110ms where an invader died. No particles, no fade. */
+export const BURST: Grid = ['█  █  █', ' █ █ █ ', '  ███  ', ' █ █ █ ', '█  █  █'];
+
+export const PLAYER: Grid = ['   █   ', '  ███  ', ' █████ ', '███████'];
+
+export const BUNKER: Grid = [' █████ ', '███████', '███████', '██   ██'];
+
+export const RANK_SPRITE: readonly SpritePair[] = [SQUID, CRAB, CRAB, OCTOPUS, OCTOPUS];
+
+/**
+ * The invaders are ranked in ink steps rather than colour, which is what
+ * reserves the accent for the player and keeps the field readable at a glance.
+ */
+export const RANK_INK: readonly string[] = [
+  '--color-ink-muted',
+  '--color-ink-secondary',
+  '--color-ink-secondary',
+  '--color-ink-body',
+  '--color-ink-body',
+];
+
+/** A grid as a row major matrix of lit cells. Bunkers erode through this. */
+export function gridCells(grid: Grid): boolean[][] {
+  return grid.map((row) => [...row].map((char) => char === '█'));
+}

--- a/src/lib/invaders/sprites.ts
+++ b/src/lib/invaders/sprites.ts
@@ -10,7 +10,7 @@
 export type Grid = readonly string[];
 export type SpritePair = { readonly a: Grid; readonly b: Grid };
 
-export const SPRITE_COLS = 7;
+export { SPRITE_COLS } from './rules';
 
 /** Rank 1, 30 points. The bottom row alternates. */
 export const SQUID: SpritePair = {

--- a/src/lib/invaders/state.ts
+++ b/src/lib/invaders/state.ts
@@ -1,0 +1,284 @@
+import { bunkerRect, createBunkers, erode, isGone, type Bunker } from './bunkers';
+import { overlaps, type Rect } from './collide';
+import {
+  alive,
+  clearBursts,
+  createFormation,
+  formationBottom,
+  invaderRect,
+  killInvader,
+  lowestInColumn,
+  occupiedColumns,
+  stepFormation,
+  type Formation,
+} from './formation';
+import {
+  advanceBombs,
+  advanceShot,
+  bombRect,
+  shotRect,
+  type Bomb,
+  type Shot,
+} from './projectiles';
+import {
+  BOMB_CHANCE,
+  BOMB_W,
+  CELL_H,
+  CELL_W,
+  GROUND_Y,
+  HIT_FLASH_MS,
+  LIVES,
+  MAX_BOMBS,
+  PLAYER_H,
+  PLAYER_SPEED,
+  PLAYER_TOP,
+  RANKS,
+  RESPAWN_MS,
+  SHOT_H,
+  SHOT_W,
+  WAVE_BONUS,
+  WAVE_CLEAR_MS,
+} from './rules';
+
+export type Phase = 'title' | 'playing' | 'waveClear' | 'gameOver' | 'paused';
+
+export interface Input {
+  left: boolean;
+  right: boolean;
+  /** True only on the frame the key went down. Holding fire does not autofire. */
+  fire: boolean;
+}
+
+/** What the game over line reports. */
+export interface Death {
+  rank: number;
+  row: number;
+}
+
+export interface GameState {
+  phase: Phase;
+  fieldW: number;
+  /** Game time in milliseconds. It only advances while the game is running. */
+  now: number;
+  score: number;
+  hi: number;
+  wave: number;
+  lives: number;
+  waveBonus: number;
+  formation: Formation;
+  playerX: number;
+  hitUntil: number;
+  respawnUntil: number;
+  shot: Shot | null;
+  bombs: Bomb[];
+  bunkers: Bunker[];
+  waveClearUntil: number;
+  death: Death | null;
+}
+
+/**
+ * Ranks count from the top by score, rows count from the bottom of the
+ * formation. That is the only reading where the handoff's "rank-1 invader at
+ * row 5" names one invader.
+ */
+export function deathFor(rank: number): Death {
+  return { rank: rank + 1, row: RANKS - rank };
+}
+
+export function playerRect(s: GameState): Rect {
+  return { x: s.playerX, y: PLAYER_TOP, w: CELL_W, h: PLAYER_H };
+}
+
+export function createGame(hi: number, fieldW: number): GameState {
+  return {
+    phase: 'title',
+    fieldW,
+    now: 0,
+    score: 0,
+    hi,
+    wave: 1,
+    lives: LIVES,
+    waveBonus: 0,
+    formation: createFormation(1, fieldW, 0),
+    playerX: (fieldW - CELL_W) / 2,
+    hitUntil: 0,
+    respawnUntil: 0,
+    shot: null,
+    bombs: [],
+    bunkers: createBunkers(fieldW),
+    waveClearUntil: 0,
+    death: null,
+  };
+}
+
+/** Starts a run from the title screen or from game over. The hi score survives. */
+export function startGame(s: GameState): void {
+  s.phase = 'playing';
+  s.score = 0;
+  s.wave = 1;
+  s.lives = LIVES;
+  s.waveBonus = 0;
+  s.formation = createFormation(1, s.fieldW, s.now);
+  s.playerX = (s.fieldW - CELL_W) / 2;
+  s.hitUntil = 0;
+  s.respawnUntil = 0;
+  s.shot = null;
+  s.bombs = [];
+  s.bunkers = createBunkers(s.fieldW);
+  s.waveClearUntil = 0;
+  s.death = null;
+}
+
+export function togglePause(s: GameState): void {
+  if (s.phase === 'playing') s.phase = 'paused';
+  else if (s.phase === 'paused') s.phase = 'playing';
+}
+
+export function step(s: GameState, dt: number, input: Input, rng: () => number): void {
+  if (s.phase === 'waveClear') {
+    s.now += dt;
+    if (s.now >= s.waveClearUntil) nextWave(s);
+    return;
+  }
+  if (s.phase !== 'playing') return;
+
+  s.now += dt;
+  clearBursts(s.formation, s.now);
+  movePlayer(s, dt, input);
+  maybeFire(s, input);
+  moveShot(s, dt);
+  // Bombs move before the beat drops a new one, for two reasons. A bomb should
+  // not be advanced by a whole frame in the frame it appears. And the beat's
+  // three-bomb limit then counts the bombs still on the field, rather than
+  // holding a slot for one that left on this frame.
+  moveBombs(s, dt);
+  runBeat(s, rng);
+  checkGround(s);
+  checkCleared(s);
+  if (s.score > s.hi) s.hi = s.score;
+}
+
+function movePlayer(s: GameState, dt: number, input: Input): void {
+  const dir = (input.right ? 1 : 0) - (input.left ? 1 : 0);
+  if (dir === 0) return;
+  const x = s.playerX + (dir * PLAYER_SPEED * dt) / 1000;
+  s.playerX = Math.min(Math.max(x, 0), s.fieldW - CELL_W);
+}
+
+function respawning(s: GameState): boolean {
+  return s.now < s.respawnUntil;
+}
+
+function maybeFire(s: GameState, input: Input): void {
+  if (!input.fire || s.shot || respawning(s)) return;
+  s.shot = { x: s.playerX + CELL_W / 2 - SHOT_W / 2, y: PLAYER_TOP - SHOT_H };
+}
+
+function moveShot(s: GameState, dt: number): void {
+  s.shot = advanceShot(s.shot, dt);
+  if (!s.shot) return;
+  const box = shotRect(s.shot);
+
+  // Bunkers sit below the formation, so the shot meets them first.
+  for (const bunker of s.bunkers) {
+    if (isGone(bunker) || !overlaps(box, bunkerRect(bunker))) continue;
+    if (erode(bunker, box.x + box.w / 2, box.y)) {
+      s.shot = null;
+      return;
+    }
+  }
+
+  for (const inv of alive(s.formation)) {
+    if (!overlaps(box, invaderRect(s.formation, inv))) continue;
+    s.score += killInvader(s.formation, inv, s.now);
+    s.shot = null;
+    return;
+  }
+}
+
+function runBeat(s: GameState, rng: () => number): void {
+  if (!stepFormation(s.formation, s.now, s.fieldW)) return;
+  if (s.bombs.length >= MAX_BOMBS) return;
+  if (rng() >= BOMB_CHANCE) return;
+
+  const cols = occupiedColumns(s.formation);
+  if (cols.length === 0) return;
+  const col = cols[Math.min(cols.length - 1, Math.floor(rng() * cols.length))];
+  const source = lowestInColumn(s.formation, col);
+  if (!source) return;
+
+  const box = invaderRect(s.formation, source);
+  s.bombs.push({
+    x: box.x + CELL_W / 2 - BOMB_W / 2,
+    y: box.y + CELL_H,
+    rank: source.rank,
+  });
+}
+
+function moveBombs(s: GameState, dt: number): void {
+  s.bombs = advanceBombs(s.bombs, dt);
+  const survivors: Bomb[] = [];
+
+  for (const bomb of s.bombs) {
+    const box = bombRect(bomb);
+    let stopped = false;
+
+    for (const bunker of s.bunkers) {
+      if (isGone(bunker) || !overlaps(box, bunkerRect(bunker))) continue;
+      if (erode(bunker, box.x + box.w / 2, box.y + box.h)) {
+        stopped = true;
+        break;
+      }
+    }
+
+    if (!stopped && !respawning(s) && overlaps(box, playerRect(s))) {
+      hitPlayer(s, bomb.rank);
+      stopped = true;
+    }
+
+    if (!stopped) survivors.push(bomb);
+  }
+
+  s.bombs = survivors;
+}
+
+function hitPlayer(s: GameState, rank: number): void {
+  s.lives -= 1;
+  s.hitUntil = s.now + HIT_FLASH_MS;
+  if (s.lives <= 0) {
+    s.death = deathFor(rank);
+    s.phase = 'gameOver';
+    return;
+  }
+  s.respawnUntil = s.now + RESPAWN_MS;
+}
+
+function checkGround(s: GameState): void {
+  if (s.phase !== 'playing') return;
+  if (formationBottom(s.formation) < GROUND_Y) return;
+  const living = alive(s.formation);
+  const lowest = living.length > 0 ? Math.max(...living.map((inv) => inv.rank)) : 0;
+  s.death = deathFor(lowest);
+  s.lives = 0;
+  s.phase = 'gameOver';
+}
+
+function checkCleared(s: GameState): void {
+  if (s.phase !== 'playing' || alive(s.formation).length > 0) return;
+  s.waveBonus = WAVE_BONUS * s.wave;
+  s.score += s.waveBonus;
+  s.phase = 'waveClear';
+  s.waveClearUntil = s.now + WAVE_CLEAR_MS;
+}
+
+function nextWave(s: GameState): void {
+  s.wave += 1;
+  s.formation = createFormation(s.wave, s.fieldW, s.now);
+  s.bunkers = createBunkers(s.fieldW);
+  s.shot = null;
+  s.bombs = [];
+  s.playerX = (s.fieldW - CELL_W) / 2;
+  s.respawnUntil = 0;
+  s.hitUntil = 0;
+  s.phase = 'playing';
+}

--- a/src/lib/invaders/state.ts
+++ b/src/lib/invaders/state.ts
@@ -242,14 +242,28 @@ function moveBombs(s: GameState, dt: number): void {
   s.bombs = survivors;
 }
 
+/**
+ * Ends the run.
+ *
+ * Clearing the timers is the point: game time stops with the phase change, so a
+ * flash or respawn timer left in the future would never expire, and the field
+ * would stay inverted behind the game over panel.
+ */
+function endGame(s: GameState, rank: number): void {
+  s.death = deathFor(rank);
+  s.lives = 0;
+  s.phase = 'gameOver';
+  s.hitUntil = 0;
+  s.respawnUntil = 0;
+}
+
 function hitPlayer(s: GameState, rank: number): void {
   s.lives -= 1;
-  s.hitUntil = s.now + HIT_FLASH_MS;
   if (s.lives <= 0) {
-    s.death = deathFor(rank);
-    s.phase = 'gameOver';
+    endGame(s, rank);
     return;
   }
+  s.hitUntil = s.now + HIT_FLASH_MS;
   s.respawnUntil = s.now + RESPAWN_MS;
 }
 
@@ -258,9 +272,7 @@ function checkGround(s: GameState): void {
   if (formationBottom(s.formation) < GROUND_Y) return;
   const living = alive(s.formation);
   const lowest = living.length > 0 ? Math.max(...living.map((inv) => inv.rank)) : 0;
-  s.death = deathFor(lowest);
-  s.lives = 0;
-  s.phase = 'gameOver';
+  endGame(s, lowest);
 }
 
 function checkCleared(s: GameState): void {

--- a/src/lib/invaders/state.ts
+++ b/src/lib/invaders/state.ts
@@ -255,6 +255,9 @@ function endGame(s: GameState, rank: number): void {
   s.phase = 'gameOver';
   s.hitUntil = 0;
   s.respawnUntil = 0;
+  // s.now freezes once the phase leaves playing, so any burst deadline still
+  // in the future would never resolve. Clear them all now, while time still moves.
+  clearBursts(s.formation, Infinity);
 }
 
 function hitPlayer(s: GameState, rank: number): void {

--- a/src/lib/invaders/transition.ts
+++ b/src/lib/invaders/transition.ts
@@ -1,0 +1,2 @@
+/** Rasterises the page ahead of the click. Task 14 gives this a body. */
+export function prepare(): void {}

--- a/src/lib/invaders/transition.ts
+++ b/src/lib/invaders/transition.ts
@@ -1,2 +1,279 @@
-/** Rasterises the page ahead of the click. Task 14 gives this a body. */
-export function prepare(): void {}
+import {
+  CELL_H,
+  CELL_W,
+  COLUMNS,
+  COLUMN_PITCH,
+  FORMATION_TOP,
+  RANKS,
+  RANK_PITCH,
+  formationLeftFor,
+} from './rules';
+import { RANK_INK, RANK_SPRITE, SPRITE_COLS, gridCells } from './sprites';
+
+/**
+ * The page dissolving into its own pixels, and resolving back as the game.
+ *
+ * One canvas covers the frozen viewport. Each frame draws the source into a
+ * small offscreen canvas and blows it back up with smoothing off, so the block
+ * size is the only thing being animated. At 520ms the source changes from the
+ * rasterised page to the game's opening formation, and the climb back in
+ * resolution is then the same operation on a different picture. That reversal is
+ * the whole idea: it is why the invaders look like they were in the page all
+ * along, and it is not a fade.
+ */
+
+const IN_MS = 720;
+const OUT_MS = 480;
+
+/** Time in milliseconds against block size in pixels, straight from the handoff. */
+const KEYFRAMES: readonly [number, number][] = [
+  [0, 1],
+  [160, 6],
+  [380, 20],
+  [520, 40],
+  [650, 8],
+  [720, 1],
+];
+
+/** Where the source stops being the page and starts being the game. */
+const SWITCH_MS = 520;
+const VEIL_FROM_MS = 380;
+const VEIL_UNTIL_MS = 650;
+const VEIL_PEAK = 0.7;
+const ARRIVE_MS = 650;
+
+const FIELD_COLOUR = '#0b0b10';
+
+let pageCanvas: HTMLCanvasElement | null = null;
+let pending: Promise<HTMLCanvasElement> | null = null;
+let listening = false;
+
+function reduced(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Rasterises the viewport, cached.
+ *
+ * At CSS pixel scale rather than device pixel scale: the output is deliberately
+ * pixelated, so device fidelity buys nothing and costs half the fill rate on the
+ * only frames that are expensive, the first few at block 1 and 2.
+ */
+function rasterise(): Promise<HTMLCanvasElement> {
+  if (pageCanvas) return Promise.resolve(pageCanvas);
+  pending ??= import('html2canvas')
+    .then(({ default: html2canvas }) =>
+      html2canvas(document.body, {
+        scale: 1,
+        logging: false,
+        backgroundColor: getComputedStyle(document.body).backgroundColor,
+        x: window.scrollX,
+        y: window.scrollY,
+        width: window.innerWidth,
+        height: window.innerHeight,
+      })
+    )
+    .then((canvas) => {
+      pageCanvas = canvas;
+      return canvas;
+    })
+    .catch((error) => {
+      pending = null;
+      throw error;
+    });
+  return pending;
+}
+
+export function invalidate(): void {
+  pageCanvas = null;
+  pending = null;
+}
+
+/** Warms the raster before the click, so the click itself feels instant. */
+export function prepare(): void {
+  if (reduced()) return;
+  if (!listening) {
+    listening = true;
+    window.addEventListener('resize', invalidate);
+    window.addEventListener('scroll', invalidate, { passive: true });
+  }
+  void rasterise().catch(() => undefined);
+}
+
+/** The game's opening formation, drawn where the real field is about to be. */
+function formationCanvas(field: DOMRect, w: number, h: number): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.round(w));
+  canvas.height = Math.max(1, Math.round(h));
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return canvas;
+
+  ctx.fillStyle = FIELD_COLOUR;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const styles = getComputedStyle(document.documentElement);
+  const cellW = CELL_W / SPRITE_COLS;
+  const cellH = CELL_H / RANKS;
+  const left = field.left + formationLeftFor(field.width);
+
+  for (let rank = 0; rank < RANKS; rank += 1) {
+    ctx.fillStyle = styles.getPropertyValue(RANK_INK[rank]).trim() || '#8b8799';
+    const cells = gridCells(RANK_SPRITE[rank].a);
+    for (let col = 0; col < COLUMNS; col += 1) {
+      const originX = left + col * COLUMN_PITCH;
+      const originY = field.top + FORMATION_TOP + rank * RANK_PITCH;
+      for (let row = 0; row < cells.length; row += 1) {
+        for (let cell = 0; cell < cells[row].length; cell += 1) {
+          if (!cells[row][cell]) continue;
+          ctx.fillRect(
+            originX + cell * cellW,
+            originY + row * cellH,
+            Math.ceil(cellW),
+            Math.ceil(cellH)
+          );
+        }
+      }
+    }
+  }
+
+  return canvas;
+}
+
+function ease(k: number): number {
+  return k < 0.5 ? 2 * k * k : 1 - 2 * (1 - k) * (1 - k);
+}
+
+/** The block size at `t`, eased inside each segment so 520ms is a real turn. */
+export function blockAt(t: number): number {
+  for (let i = 1; i < KEYFRAMES.length; i += 1) {
+    const [t0, b0] = KEYFRAMES[i - 1];
+    const [t1, b1] = KEYFRAMES[i];
+    if (t <= t1) return b0 + (b1 - b0) * ease((t - t0) / (t1 - t0));
+  }
+  return 1;
+}
+
+/**
+ * How far the frame is lerped toward the field colour at `t`.
+ *
+ * The handoff builds this from 380ms and does not say it comes off again. It has
+ * to: the invaders resolve out of the same pixels, and under a 70% veil they
+ * would never appear.
+ */
+export function veilAt(t: number): number {
+  if (t < VEIL_FROM_MS) return 0;
+  if (t < SWITCH_MS) return (VEIL_PEAK * (t - VEIL_FROM_MS)) / (SWITCH_MS - VEIL_FROM_MS);
+  if (t < VEIL_UNTIL_MS) return VEIL_PEAK * (1 - (t - SWITCH_MS) / (VEIL_UNTIL_MS - SWITCH_MS));
+  return 0;
+}
+
+/**
+ * Runs the pixelation. `in` dissolves the page into the game, `out` reverses it
+ * over 480ms with the page as the destination.
+ *
+ * Resolves once the canvas is gone. Under reduced motion it resolves after a
+ * 120ms crossfade and never makes a canvas at all.
+ */
+export async function run(field: DOMRect, direction: 'in' | 'out'): Promise<void> {
+  const root = document.querySelector<HTMLElement>('[data-invaders-root]');
+
+  if (reduced()) {
+    if (root) {
+      root.style.transition = 'opacity 120ms linear';
+      root.style.opacity = direction === 'in' ? '0' : '1';
+      // Forces the starting value to land before the target does.
+      void root.offsetWidth;
+      root.style.opacity = direction === 'in' ? '1' : '0';
+    }
+    await wait(120);
+    if (root) {
+      root.style.transition = '';
+      root.style.opacity = '';
+    }
+    return;
+  }
+
+  const w = window.innerWidth;
+  const h = window.innerHeight;
+  const raster = await rasterise().catch(() => null);
+  if (!raster) return;
+  const page = raster;
+
+  const game = formationCanvas(field, w, h);
+  const canvas = document.createElement('canvas');
+  canvas.dataset.invadersCanvas = '';
+  canvas.width = w;
+  canvas.height = h;
+  canvas.style.cssText = `position:fixed;inset:0;width:100%;height:100%;z-index:60;pointer-events:none`;
+  document.body.append(canvas);
+
+  const rawCtx = canvas.getContext('2d');
+  const small = document.createElement('canvas');
+  const rawSmallCtx = small.getContext('2d');
+  if (!rawCtx || !rawSmallCtx) {
+    canvas.remove();
+    return;
+  }
+  // Rebound so the nested frame closure below sees the narrowed, non-null
+  // type rather than the getContext() result TypeScript cannot narrow across
+  // a function boundary.
+  const ctx = rawCtx;
+  const smallCtx = rawSmallCtx;
+
+  root?.setAttribute('data-arriving', '');
+
+  const total = direction === 'in' ? IN_MS : OUT_MS;
+  const start = performance.now();
+
+  await new Promise<void>((resolve) => {
+    function frame(now: number): void {
+      const elapsed = Math.min(total, now - start);
+      // The exit is the same curve, played backwards and compressed.
+      const t = direction === 'in' ? elapsed : IN_MS * (1 - elapsed / total);
+
+      const block = Math.max(1, blockAt(t));
+      // Both directions read the same curve, so `t` already carries the direction.
+      const source = t < SWITCH_MS ? page : game;
+
+      const sw = Math.max(1, Math.round(w / block));
+      const sh = Math.max(1, Math.round(h / block));
+      small.width = sw;
+      small.height = sh;
+      smallCtx.drawImage(source, 0, 0, sw, sh);
+
+      ctx.imageSmoothingEnabled = false;
+      ctx.clearRect(0, 0, w, h);
+      ctx.drawImage(small, 0, 0, sw, sh, 0, 0, w, h);
+
+      const veil = veilAt(t);
+      if (veil > 0) {
+        ctx.globalAlpha = veil;
+        ctx.fillStyle = FIELD_COLOUR;
+        ctx.fillRect(0, 0, w, h);
+        ctx.globalAlpha = 1;
+      }
+
+      // The canvas comes down here too, not just at the end: the HUD and
+      // footer slide into view over the 70ms after this, on the real DOM, and
+      // that motion would be invisible under a canvas that outlives it.
+      if (direction === 'in' && elapsed >= ARRIVE_MS) {
+        root?.removeAttribute('data-arriving');
+        canvas.remove();
+      }
+
+      if (elapsed >= total) {
+        resolve();
+        return;
+      }
+      requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+  });
+
+  canvas.remove();
+  root?.removeAttribute('data-arriving');
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}

--- a/src/lib/invaders/view.ts
+++ b/src/lib/invaders/view.ts
@@ -11,10 +11,14 @@ import {
   MAX_BOMBS,
   PLAYER_TOP,
   RANK_PITCH,
+  SCORES,
+  SCORE_TABLE_SPRITE_PX,
+  SCORE_TABLE_SPRITE_W,
   SHOT_H,
   SHOT_W,
   SPRITE_LINE_HEIGHT,
   SPRITE_PX,
+  WAVE_CLEAR_MS,
 } from './rules';
 import { BURST, CRAB, OCTOPUS, PLAYER, RANK_INK, RANK_SPRITE, SQUID, type Grid } from './sprites';
 import type { GameState, Phase } from './state';
@@ -187,10 +191,13 @@ function buildLives(refs: Refs): void {
 
 /** The title screen's score table, which is how the original taught its rules. */
 function buildScoreTable(refs: Refs): void {
+  // The points come from SCORES rather than being written out again. This table
+  // is how the game teaches its own scoring, so a legend that drifts from what
+  // the game pays out would be worse than no legend.
   const rows: [Grid, number, string][] = [
-    [SQUID.a, 30, RANK_INK[0]],
-    [CRAB.a, 20, RANK_INK[1]],
-    [OCTOPUS.a, 10, RANK_INK[3]],
+    [SQUID.a, SCORES[0], RANK_INK[0]],
+    [CRAB.a, SCORES[1], RANK_INK[1]],
+    [OCTOPUS.a, SCORES[3], RANK_INK[3]],
   ];
   refs.scoreTable.replaceChildren();
   for (const [grid, points, ink] of rows) {
@@ -198,9 +205,9 @@ function buildScoreTable(refs: Refs): void {
     row.className = 'flex items-center gap-4';
 
     const pre = sprite(grid, 'invaders-table-sprite');
-    pre.style.setProperty('--invaders-sprite-px', px(11));
+    pre.style.setProperty('--invaders-sprite-px', px(SCORE_TABLE_SPRITE_PX));
     pre.style.setProperty('--invaders-ink', `var(${ink})`);
-    pre.style.width = px(60);
+    pre.style.width = px(SCORE_TABLE_SPRITE_W);
 
     const value = document.createElement('span');
     value.className = 'text-md text-ink-body';
@@ -282,7 +289,9 @@ function renderPanels(refs: Refs, s: GameState): void {
   if (s.phase === 'waveClear') {
     refs.cleared.textContent = `WAVE ${pad(s.wave, 2)} CLEARED`;
     refs.bonus.textContent = String(s.waveBonus);
-    refs.nextWave.textContent = `wave ${pad(s.wave + 1, 2)} in 2s · they come down faster now`;
+    const seconds = WAVE_CLEAR_MS / 1000;
+    refs.nextWave.textContent =
+      `wave ${pad(s.wave + 1, 2)} in ${seconds}s · they come down faster now`;
   }
 
   if (s.phase === 'gameOver' && s.death) {

--- a/src/lib/invaders/view.ts
+++ b/src/lib/invaders/view.ts
@@ -1,0 +1,299 @@
+import { bunkerRows, isGone } from './bunkers';
+import {
+  BOMB_H,
+  BOMB_W,
+  BUNKER_TOP,
+  COLUMN_PITCH,
+  FIELD_H,
+  GROUND_FROM_BOTTOM,
+  LIVES,
+  LIVES_SPRITE_PX,
+  MAX_BOMBS,
+  PLAYER_TOP,
+  RANK_PITCH,
+  SHOT_H,
+  SHOT_W,
+  SPRITE_LINE_HEIGHT,
+  SPRITE_PX,
+} from './rules';
+import { BURST, CRAB, OCTOPUS, PLAYER, RANK_INK, RANK_SPRITE, SQUID, type Grid } from './sprites';
+import type { GameState, Phase } from './state';
+
+export interface Refs {
+  root: HTMLElement;
+  field: HTMLElement;
+  formation: HTMLElement;
+  bunkers: HTMLElement;
+  bombs: HTMLElement;
+  shot: HTMLElement;
+  player: HTMLElement;
+  score: HTMLElement;
+  hi: HTMLElement;
+  wave: HTMLElement;
+  lives: HTMLElement;
+  scoreTable: HTMLElement;
+  cleared: HTMLElement;
+  bonus: HTMLElement;
+  nextWave: HTMLElement;
+  death: HTMLElement;
+  exit: HTMLElement;
+  /** Indexed exactly as `state.formation.invaders`. */
+  invaders: HTMLElement[];
+  bunkerPres: HTMLPreElement[];
+  bombEls: HTMLElement[];
+}
+
+const PHASES: Phase[] = ['title', 'playing', 'waveClear', 'gameOver', 'paused'];
+
+function need<T extends HTMLElement>(root: HTMLElement, selector: string): T {
+  const el = root.querySelector<T>(selector);
+  if (!el) throw new Error(`invaders: the shell is missing ${selector}`);
+  return el;
+}
+
+export function collect(root: HTMLElement): Refs {
+  return {
+    root,
+    field: need(root, '[data-invaders-field]'),
+    formation: need(root, '[data-invaders-formation]'),
+    bunkers: need(root, '[data-invaders-bunkers]'),
+    bombs: need(root, '[data-invaders-bombs]'),
+    shot: need(root, '[data-invaders-shot]'),
+    player: need(root, '[data-invaders-player]'),
+    score: need(root, '[data-invaders-score]'),
+    hi: need(root, '[data-invaders-hi]'),
+    wave: need(root, '[data-invaders-wave]'),
+    lives: need(root, '[data-invaders-lives]'),
+    scoreTable: need(root, '[data-invaders-score-table]'),
+    cleared: need(root, '[data-invaders-cleared]'),
+    bonus: need(root, '[data-invaders-bonus]'),
+    nextWave: need(root, '[data-invaders-next-wave]'),
+    death: need(root, '[data-invaders-death]'),
+    exit: need(root, '[data-invaders-exit]'),
+    invaders: [],
+    bunkerPres: [],
+    bombEls: [],
+  };
+}
+
+/**
+ * A sprite: a `<pre>` with one `<div>` per row.
+ *
+ * One block element per line, the same rule `CodeBlock` obeys and for the same
+ * reason: newlines between inline elements are not reliable. `font-mono` comes
+ * from `.invaders-sprite`, because preflight points every `pre` at the reading
+ * face and a sprite is not prose.
+ */
+function sprite(grid: Grid, className: string): HTMLPreElement {
+  const pre = document.createElement('pre');
+  pre.className = `invaders-sprite ${className}`;
+  for (const row of grid) {
+    const line = document.createElement('div');
+    line.textContent = row;
+    pre.append(line);
+  }
+  return pre;
+}
+
+function px(value: number): string {
+  return `${value}px`;
+}
+
+function pad(value: number, width: number): string {
+  return String(Math.max(0, Math.trunc(value))).padStart(width, '0');
+}
+
+/** Writes the game metrics onto the field, once, as custom properties. */
+function setMetrics(refs: Refs): void {
+  const field = refs.field.style;
+  field.setProperty('--invaders-field-h', px(FIELD_H));
+  field.setProperty('--invaders-ground', px(GROUND_FROM_BOTTOM));
+  field.setProperty('--invaders-sprite-px', px(SPRITE_PX));
+  field.setProperty('--invaders-line-height', String(SPRITE_LINE_HEIGHT));
+  field.setProperty('--invaders-player-top', px(PLAYER_TOP));
+  field.setProperty('--invaders-shot-w', px(SHOT_W));
+  field.setProperty('--invaders-shot-h', px(SHOT_H));
+  field.setProperty('--invaders-bomb-w', px(BOMB_W));
+  field.setProperty('--invaders-bomb-h', px(BOMB_H));
+}
+
+/**
+ * Builds everything made of sprites. Runs once per wave.
+ *
+ * Both sprite frames exist in the DOM for every invader, and the field decides
+ * which shows. That is what makes a beat one attribute write rather than 225
+ * text writes.
+ */
+export function build(refs: Refs, s: GameState): void {
+  setMetrics(refs);
+
+  refs.formation.replaceChildren();
+  refs.invaders = s.formation.invaders.map((inv) => {
+    const el = document.createElement('div');
+    el.className = 'invaders-invader';
+    el.dataset.state = 'alive';
+    el.style.setProperty('--invaders-x', px(inv.col * COLUMN_PITCH));
+    el.style.setProperty('--invaders-y', px(inv.rank * RANK_PITCH));
+    el.style.setProperty('--invaders-ink', `var(${RANK_INK[inv.rank]})`);
+    const pair = RANK_SPRITE[inv.rank];
+    el.append(
+      sprite(pair.a, 'invaders-frame-a'),
+      sprite(pair.b, 'invaders-frame-b'),
+      sprite(BURST, 'invaders-burst')
+    );
+    refs.formation.append(el);
+    return el;
+  });
+
+  refs.bunkers.replaceChildren();
+  refs.bunkerPres = s.bunkers.map((bunker) => {
+    const wrap = document.createElement('div');
+    wrap.className = 'invaders-bunker';
+    wrap.style.setProperty('--invaders-x', px(bunker.x));
+    wrap.style.setProperty('--invaders-y', px(BUNKER_TOP));
+    wrap.style.setProperty('--invaders-ink', 'var(--color-ink-faint)');
+    const pre = sprite(bunkerRows(bunker), 'invaders-bunker-sprite');
+    wrap.append(pre);
+    refs.bunkers.append(wrap);
+    return pre;
+  });
+
+  refs.player.replaceChildren(sprite(PLAYER, 'invaders-player-sprite'));
+  refs.player.style.setProperty('--invaders-ink', 'var(--color-accent)');
+
+  refs.bombs.replaceChildren();
+  refs.bombEls = Array.from({ length: MAX_BOMBS }, () => {
+    const el = document.createElement('div');
+    el.className = 'invaders-bomb';
+    el.hidden = true;
+    refs.bombs.append(el);
+    return el;
+  });
+
+  buildLives(refs);
+  buildScoreTable(refs);
+}
+
+/** One 7px cannon per life, drawn rather than counted. */
+function buildLives(refs: Refs): void {
+  refs.lives.replaceChildren();
+  for (let i = 0; i < LIVES; i += 1) {
+    const pre = sprite(PLAYER, 'invaders-life');
+    pre.style.setProperty('--invaders-sprite-px', px(LIVES_SPRITE_PX));
+    pre.style.setProperty('--invaders-ink', 'var(--color-accent)');
+    refs.lives.append(pre);
+  }
+}
+
+/** The title screen's score table, which is how the original taught its rules. */
+function buildScoreTable(refs: Refs): void {
+  const rows: [Grid, number, string][] = [
+    [SQUID.a, 30, RANK_INK[0]],
+    [CRAB.a, 20, RANK_INK[1]],
+    [OCTOPUS.a, 10, RANK_INK[3]],
+  ];
+  refs.scoreTable.replaceChildren();
+  for (const [grid, points, ink] of rows) {
+    const row = document.createElement('div');
+    row.className = 'flex items-center gap-4';
+
+    const pre = sprite(grid, 'invaders-table-sprite');
+    pre.style.setProperty('--invaders-sprite-px', px(11));
+    pre.style.setProperty('--invaders-ink', `var(${ink})`);
+    pre.style.width = px(60);
+
+    const value = document.createElement('span');
+    value.className = 'text-md text-ink-body';
+    value.textContent = `= ${points} PTS`;
+
+    row.append(pre, value);
+    refs.scoreTable.append(row);
+  }
+}
+
+/** Runs once a frame. Writes only transforms, text and attributes. */
+export function render(refs: Refs, s: GameState): void {
+  refs.score.textContent = pad(s.score, 6);
+  refs.hi.textContent = pad(s.hi, 6);
+  refs.wave.textContent = pad(s.wave, 2);
+
+  const lives = refs.lives.children;
+  for (let i = 0; i < lives.length; i += 1) {
+    (lives[i] as HTMLElement).hidden = i >= s.lives;
+  }
+
+  refs.field.dataset.frame = s.formation.frame;
+  refs.formation.style.transform = `translate3d(${s.formation.left}px, ${s.formation.top}px, 0)`;
+
+  for (let i = 0; i < refs.invaders.length; i += 1) {
+    const inv = s.formation.invaders[i];
+    refs.invaders[i].dataset.state = inv.alive
+      ? 'alive'
+      : inv.burstUntil > s.now
+        ? 'burst'
+        : 'dead';
+  }
+
+  for (let i = 0; i < refs.bunkerPres.length; i += 1) {
+    const bunker = s.bunkers[i];
+    const pre = refs.bunkerPres[i];
+    if (isGone(bunker)) {
+      pre.hidden = true;
+      continue;
+    }
+    const rows = bunkerRows(bunker);
+    for (let row = 0; row < rows.length; row += 1) {
+      const line = pre.children[row] as HTMLElement;
+      if (line.textContent !== rows[row]) line.textContent = rows[row];
+    }
+  }
+
+  refs.player.style.transform = `translate3d(${s.playerX}px, 0, 0)`;
+  toggle(refs.player, 'respawning', s.now < s.respawnUntil);
+  toggle(refs.field, 'hit', s.now < s.hitUntil);
+  toggle(refs.field, 'dim', s.phase === 'paused');
+
+  refs.shot.hidden = s.shot === null;
+  if (s.shot) refs.shot.style.transform = `translate3d(${s.shot.x}px, ${s.shot.y}px, 0)`;
+
+  for (let i = 0; i < refs.bombEls.length; i += 1) {
+    const bomb = s.bombs[i];
+    const el = refs.bombEls[i];
+    el.hidden = bomb === undefined;
+    if (bomb) el.style.transform = `translate3d(${bomb.x}px, ${bomb.y}px, 0)`;
+  }
+
+  renderPanels(refs, s);
+}
+
+function toggle(el: HTMLElement, name: string, on: boolean): void {
+  if (on) el.setAttribute(`data-${name}`, '');
+  else el.removeAttribute(`data-${name}`);
+}
+
+function renderPanels(refs: Refs, s: GameState): void {
+  for (const phase of PHASES) {
+    const panel = refs.root.querySelector<HTMLElement>(`[data-invaders-panel="${phase}"]`);
+    if (panel) panel.hidden = phase !== s.phase;
+    const footer = refs.root.querySelector<HTMLElement>(`[data-invaders-footer="${phase}"]`);
+    if (footer) footer.hidden = phase !== footerFor(s.phase);
+  }
+
+  if (s.phase === 'waveClear') {
+    refs.cleared.textContent = `WAVE ${pad(s.wave, 2)} CLEARED`;
+    refs.bonus.textContent = String(s.waveBonus);
+    refs.nextWave.textContent = `wave ${pad(s.wave + 1, 2)} in 2s · they come down faster now`;
+  }
+
+  if (s.phase === 'gameOver' && s.death) {
+    refs.death.textContent = `invaders: killed by rank-${s.death.rank} invader at row ${s.death.row}`;
+    // 137 is what a shell reports for a process killed outright. It is the joke,
+    // and it is not an apology.
+    refs.exit.textContent = `exit 137 · score ${pad(s.score, 6)} · hi ${pad(s.hi, 6)}`;
+  }
+}
+
+/** Title and wave clear borrow the playing footer: the controls have not changed. */
+function footerFor(phase: Phase): Phase {
+  return phase === 'title' || phase === 'waveClear' ? 'playing' : phase;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,4 @@
 @import "tailwindcss";
 @import "./theme.css";
 @import "./code-vars.css";
+@import "./invaders.css";

--- a/src/styles/invaders.css
+++ b/src/styles/invaders.css
@@ -1,0 +1,123 @@
+/* ============================================================
+   INVADERS. The field and its sprites.
+
+   Every length here reads a custom property that `view.ts` sets from
+   `src/lib/invaders/rules.ts`. Those are game metrics, not design
+   values: none of them sits on the 11 and 5.5 pixel grid, so none of
+   them belongs in theme.css and none of them may become an arbitrary
+   Tailwind value at a call site.
+   ============================================================ */
+
+[data-invaders-field] {
+  height: var(--invaders-field-h);
+  background: var(--game-field);
+}
+
+[data-invaders-ground] {
+  bottom: var(--invaders-ground);
+}
+
+/* One step fainter than the page's .05: the page's own overlay sits above this
+   one, and two layers at the same alpha read as one dark band. */
+.invaders-scan {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    180deg,
+    rgb(169 139 245 / 0.04) 0 1px,
+    transparent 1px 4px
+  );
+  animation: var(--animate-scan);
+}
+
+/* Sprites. One block element per row inside the `pre`, the same rule CodeBlock
+   obeys and for the same reason: newlines between inline elements are not
+   reliable. `font-mono` is asked for explicitly because preflight points every
+   `pre` at the reading face. */
+.invaders-sprite {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--invaders-sprite-px);
+  line-height: var(--invaders-line-height);
+  white-space: pre;
+  color: var(--invaders-ink);
+}
+
+.invaders-invader,
+.invaders-bunker {
+  position: absolute;
+  left: var(--invaders-x);
+  top: var(--invaders-y);
+}
+
+.invaders-invader > .invaders-sprite {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+/* Both frames sit in the DOM for every invader. The field says which one shows,
+   so a beat costs one attribute write instead of 225 text writes. */
+[data-frame='a'] .invaders-invader[data-state='alive'] .invaders-frame-b,
+[data-frame='b'] .invaders-invader[data-state='alive'] .invaders-frame-a,
+.invaders-invader[data-state='burst'] .invaders-frame-a,
+.invaders-invader[data-state='burst'] .invaders-frame-b,
+.invaders-invader[data-state='alive'] .invaders-burst {
+  visibility: hidden;
+}
+
+.invaders-invader[data-state='dead'] {
+  visibility: hidden;
+}
+
+/* The player and its shot are the only things on the field allowed the accent. */
+[data-invaders-player] {
+  position: absolute;
+  top: var(--invaders-player-top);
+  left: 0;
+  will-change: transform;
+}
+
+[data-invaders-shot],
+.invaders-bomb {
+  position: absolute;
+  left: 0;
+  top: 0;
+  will-change: transform;
+}
+
+[data-invaders-shot] {
+  width: var(--invaders-shot-w);
+  height: var(--invaders-shot-h);
+  background: var(--color-accent-lift);
+}
+
+.invaders-bomb {
+  width: var(--invaders-bomb-w);
+  height: var(--invaders-bomb-h);
+  background: var(--color-ink-muted);
+}
+
+[hidden] {
+  display: none !important;
+}
+
+/* A hit inverts the field for one flash, then the cannon comes back at 40%. */
+[data-invaders-field][data-hit] {
+  background: var(--color-accent);
+}
+
+[data-invaders-player][data-respawning] {
+  opacity: 0.4;
+}
+
+[data-invaders-field][data-dim] > *:not([data-invaders-panel]) {
+  opacity: 0.4;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .invaders-scan {
+    animation: none;
+  }
+}

--- a/src/styles/invaders.css
+++ b/src/styles/invaders.css
@@ -22,6 +22,7 @@
 .invaders-scan {
   position: absolute;
   inset: 0;
+  z-index: 1;
   pointer-events: none;
   background: repeating-linear-gradient(
     180deg,
@@ -29,6 +30,15 @@
     transparent 1px 4px
   );
   animation: var(--animate-scan);
+}
+
+/* Title, wave clear and game over take over the field: the design draws all three
+   on a clean field surface. Pause is the exception, dimming the frozen game so you
+   can still see what you are coming back to. */
+[data-invaders-panel='title'],
+[data-invaders-panel='waveClear'],
+[data-invaders-panel='gameOver'] {
+  background: var(--game-field);
 }
 
 /* Sprites. One block element per row inside the `pre`, the same rule CodeBlock

--- a/src/styles/invaders.css
+++ b/src/styles/invaders.css
@@ -121,3 +121,18 @@
     animation: none;
   }
 }
+
+/* 650ms to 720ms: the HUD and the footer arrive from the frame edges. The
+   global reduced-motion rule in theme.css flattens both. */
+[data-invaders-hud],
+[data-invaders-chrome-footer] {
+  transition: transform 70ms linear;
+}
+
+[data-invaders-root][data-arriving] [data-invaders-hud] {
+  transform: translateY(-100%);
+}
+
+[data-invaders-root][data-arriving] [data-invaders-chrome-footer] {
+  transform: translateY(100%);
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -95,6 +95,11 @@
   --tracking-label:   .14em;
   --tracking-section: .18em;
 
+  /* The title screen's B P A U L I N O . C O M. The scale names its entries
+     after their use, so this one follows suit rather than becoming an
+     arbitrary value at the call site. */
+  --tracking-title: .3em;
+
   /* ---- radius & shadow: there are none ---------------------- */
   --radius-none: 0px;
 
@@ -107,6 +112,12 @@
   --animate-blink: console-blink 1.1s steps(1) infinite;
   --animate-scan:  console-scan 1.6s linear infinite;
   --animate-sweep: console-sweep 3.4s ease-in-out infinite;
+
+  /* The game. Two values, which is all it adds to the system: the opening beat,
+     and a name for the field surface so the game is not reaching for a token
+     called "code". */
+  --game-beat: 620ms;
+  --game-field: var(--color-surface-code);
 
   @keyframes console-blink { 0%, 49% { opacity: 1 } 50%, 100% { opacity: 0 } }
   @keyframes console-scan  { from { transform: translateY(0) } to { transform: translateY(8px) } }

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -188,7 +188,11 @@ test.describe('opening and closing', () => {
     await page.keyboard.press('i');
     await page.keyboard.press('n');
     await page.keyboard.press('v');
-    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+    const root = page.locator('[data-invaders-root]');
+    await expect(root).toBeVisible();
+    // The design arms input at 720ms; Escape sent before that lands on
+    // nothing, so the close half of this round trip goes untested.
+    await expect(root).toHaveAttribute('data-armed', '');
     await page.keyboard.press('Escape');
 
     await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
@@ -202,9 +206,11 @@ test.describe('opening and closing', () => {
     const history = await page.evaluate(() => window.history.length);
 
     await page.locator('[data-invaders-open]').click();
-    // Without this wait, Escape can land before openGame's dynamic import
-    // resolves, so the close half of this round trip goes untested.
-    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+    const root = page.locator('[data-invaders-root]');
+    // Without this wait, Escape can land before input is armed at 720ms, so
+    // the close half of this round trip goes untested.
+    await expect(root).toBeVisible();
+    await expect(root).toHaveAttribute('data-armed', '');
     await page.keyboard.press('Escape');
 
     expect(page.url()).toBe(url);
@@ -217,6 +223,10 @@ test.describe('opening and closing', () => {
 
     await page.locator('[data-invaders-open]').click();
     await expect(root).toBeVisible();
+    // The design arms input at 720ms; Escape sent before that lands on
+    // nothing, so the game never closes and the reopen below has nothing to
+    // reopen.
+    await expect(root).toHaveAttribute('data-armed', '');
     await page.keyboard.press('Escape');
     await expect(root).toHaveCount(0);
 
@@ -228,22 +238,38 @@ test.describe('opening and closing', () => {
   test('hands focus back to the trigger on exit', async ({ page }) => {
     await page.goto('/posts/');
     await page.locator('[data-invaders-open]').click();
-    // openGame is behind a dynamic import; without this wait Escape can
-    // race the import and land before the game (and its listener) exists.
-    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+    const root = page.locator('[data-invaders-root]');
+    await expect(root).toBeVisible();
+    // The design arms input at 720ms; Escape sent before that lands on
+    // nothing, so focus never moves and this assertion is really testing that
+    // Escape did nothing rather than that it worked.
+    await expect(root).toHaveAttribute('data-armed', '');
     await page.keyboard.press('Escape');
+    // closeGame runs its own 480ms exit transition before it hands focus
+    // back; checking activeElement before the window is gone would just be
+    // reading the focus the opening click already left on the trigger.
+    await expect(root).toHaveCount(0);
     expect(
       await page.evaluate(() => document.activeElement?.hasAttribute('data-invaders-open') === true)
     ).toBe(true);
   });
 });
 
-/** Opens the game and waits for the font, which every measurement depends on. */
+/**
+ * Opens the game and waits for the font, which every measurement depends on, and
+ * for input to be armed.
+ *
+ * Waiting for `data-armed` rather than for the window to appear is what makes
+ * these tests independent of the transition: the design arms input at 720ms, so a
+ * keypress sent when the window first paints has nothing listening for it.
+ */
 async function openGame(page: Page) {
   await page.goto('/posts/');
   await page.evaluate(() => document.fonts.ready);
   await page.locator('[data-invaders-open]').click();
-  await expect(page.locator('[data-invaders-root]')).toBeVisible();
+  const root = page.locator('[data-invaders-root]');
+  await expect(root).toBeVisible();
+  await expect(root).toHaveAttribute('data-armed', '');
 }
 
 test.describe('the game', () => {
@@ -406,6 +432,10 @@ test.describe('the game', () => {
     await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
 
     await page.locator('[data-invaders-open]').click();
+    const root = page.locator('[data-invaders-root]');
+    // Reopening bypasses the openGame helper, so it needs its own wait: Space
+    // sent before 720ms would land before input is armed.
+    await expect(root).toHaveAttribute('data-armed', '');
     await page.keyboard.press('Space');
     await page.keyboard.press('Escape');
     await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
@@ -448,6 +478,9 @@ test.describe('the transition', () => {
     await page.locator('[data-invaders-open]').click();
     await expect(page.locator('[data-invaders-canvas]')).toBeVisible();
     await expect(page.locator('[data-invaders-canvas]')).toHaveCount(0, { timeout: 4000 });
+    // The canvas comes down at 650ms, ahead of the 720ms mark where input
+    // arms; without this wait Escape can land in that gap and do nothing.
+    await expect(page.locator('[data-invaders-root]')).toHaveAttribute('data-armed', '');
     await page.keyboard.press('Escape');
     await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
 
@@ -473,6 +506,9 @@ test.describe('the transition', () => {
     await page.emulateMedia({ reducedMotion: 'reduce' });
     await page.goto('/posts/');
     await page.locator('[data-invaders-open]').click();
+    const root = page.locator('[data-invaders-root]');
+    await expect(root).toBeVisible();
+    await expect(root).toHaveAttribute('data-armed', '');
 
     const pulse = await page
       .locator('.invaders-pulse')

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/** The trigger exists above 900px on a fine pointer, and nowhere else. */
+function isDesktop(page: Page): boolean {
+  return (page.viewportSize()?.width ?? 0) >= 900;
+}
+
+test.describe('the trigger', () => {
+  test('is a button above 900px, and an inert square below', async ({ page }) => {
+    await page.goto('/posts/');
+    const button = page.locator('[data-invaders-open]');
+
+    if (isDesktop(page)) {
+      await expect(button).toBeVisible();
+      await expect(button).toHaveAttribute('aria-label', 'Play invaders');
+    } else {
+      await expect(button).toHaveCount(1);
+      await expect(button).toBeHidden();
+    }
+  });
+
+  test('keeps the chrome dot count and the 9px square', async ({ page }) => {
+    // The button replaces one dot rather than adding one. If both the button and
+    // the inert span showed, the chrome title would shift and layout.spec.ts
+    // would count four.
+    await page.goto('/posts/');
+    const visible = await page.locator('[data-chrome-dot]').evaluateAll((els) =>
+      els
+        .filter((el) => getComputedStyle(el).display !== 'none')
+        .map((el) => el.getBoundingClientRect().width)
+    );
+    const expected = (page.viewportSize()?.width ?? 0) >= 640 ? 3 : 2;
+    expect(visible).toHaveLength(expected);
+    for (const width of visible) expect(width).toBeLessThanOrEqual(9);
+  });
+
+  test('gives no hint at all until it is hovered', async ({ page }) => {
+    test.skip(!isDesktop(page), 'the trigger does not exist below 900px');
+    await page.goto('/posts/');
+
+    await expect(page.locator('[data-invaders-hint]')).toBeHidden();
+    await expect(page.locator('[data-chrome-meta]')).toBeVisible();
+    // No tooltip, and no cursor change on the bar as a whole.
+    await expect(page.locator('[data-invaders-open]')).not.toHaveAttribute('title', /./);
+  });
+
+  test('swaps the chrome meta for ./invaders on hover', async ({ page }) => {
+    test.skip(!isDesktop(page), 'the trigger does not exist below 900px');
+    await page.goto('/posts/');
+
+    await page.locator('[data-invaders-open]').hover();
+
+    const hint = page.locator('[data-invaders-hint]');
+    await expect(hint).toBeVisible();
+    await expect(hint).toContainText('./invaders');
+    await expect(page.locator('[data-chrome-meta]')).toBeHidden();
+  });
+
+  test('has a 24px hit area without a 24px box', async ({ page }) => {
+    test.skip(!isDesktop(page), 'the trigger does not exist below 900px');
+    await page.goto('/posts/');
+
+    const box = await page.locator('[data-invaders-open]').evaluate((el) => {
+      const own = el.getBoundingClientRect();
+      const after = getComputedStyle(el, '::after');
+      return { w: own.width, h: own.height, inset: after.inset };
+    });
+
+    expect(box.w).toBeCloseTo(9, 1);
+    expect(box.h).toBeCloseTo(9, 1);
+    expect(box.inset).toContain('-7.5px');
+  });
+
+  test('is reachable by Tab', async ({ page }) => {
+    test.skip(!isDesktop(page), 'the trigger does not exist below 900px');
+    await page.goto('/posts/');
+
+    for (let i = 0; i < 12; i += 1) {
+      await page.keyboard.press('Tab');
+      const onTrigger = await page.evaluate(
+        () => document.activeElement?.hasAttribute('data-invaders-open') === true
+      );
+      if (onTrigger) {
+        await expect(page.locator('[data-invaders-hint]')).toBeVisible();
+        return;
+      }
+    }
+    throw new Error('Tab never reached the trigger in 12 stops');
+  });
+
+  test('leaves only one caret animating at rest', async ({ page }) => {
+    await page.goto('/posts/');
+    const animating = await page
+      .locator('.caret')
+      .evaluateAll((els) => els.filter((el) => getComputedStyle(el).animationName !== 'none').length);
+    expect(animating).toBeLessThanOrEqual(1);
+  });
+});
+
+test.describe('on a coarse pointer', () => {
+  // Width alone does not prove the pointer gate. Chromium reports
+  // `pointer: coarse` only under mobile emulation, so this block asks for a
+  // touch context at a desktop width.
+  test.use({ hasTouch: true, isMobile: true, viewport: { width: 1200, height: 800 } });
+
+  test('the trigger is absent even at 1200px', async ({ page }) => {
+    await page.goto('/posts/');
+    await expect(page.locator('[data-invaders-open]')).toBeHidden();
+    // Four `[data-chrome-dot]` elements exist in DOM order now: two inert
+    // squares, the button (index 2, hidden here), then the accent span that
+    // takes its place. Index 3, not 2, is the one still on screen.
+    await expect(page.locator('[data-chrome-dot]').nth(3)).toBeVisible();
+  });
+});

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -202,10 +202,27 @@ test.describe('opening and closing', () => {
     const history = await page.evaluate(() => window.history.length);
 
     await page.locator('[data-invaders-open]').click();
+    // Without this wait, Escape can land before openGame's dynamic import
+    // resolves, so the close half of this round trip goes untested.
+    await expect(page.locator('[data-invaders-root]')).toBeVisible();
     await page.keyboard.press('Escape');
 
     expect(page.url()).toBe(url);
     expect(await page.evaluate(() => window.history.length)).toBe(history);
+  });
+
+  test('opens again cleanly after closing', async ({ page }) => {
+    await page.goto('/posts/');
+    const root = page.locator('[data-invaders-root]');
+
+    await page.locator('[data-invaders-open]').click();
+    await expect(root).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(root).toHaveCount(0);
+
+    await page.locator('[data-invaders-open]').click();
+    await expect(root).toHaveCount(1);
+    await expect(page.locator('[data-invaders-open]')).toHaveAttribute('data-open', '');
   });
 
   test('hands focus back to the trigger on exit', async ({ page }) => {

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -322,19 +322,46 @@ test.describe('the game', () => {
     expect(await x()).toBeCloseTo(field, 0);
   });
 
-  test('fires one shot, and holding SPACE does not autofire', async ({ page }) => {
+  test('fires one shot', async ({ page }) => {
     await openGame(page);
     await page.keyboard.press('Space');
 
     await page.keyboard.press('Space');
     await expect(page.locator('[data-invaders-shot]')).toBeVisible();
+  });
 
+  test('holding SPACE does not autofire', async ({ page }) => {
+    // Not runnable as specified: see task-12-report.md, fix round 1, for why.
+    // In short, a wave 1 shot fired from the centre muzzle hits the centre
+    // column's bottom-rank invader around t=90ms, so `[data-invaders-shot]` is
+    // already null well before the 300ms read below, with or without the
+    // `event.repeat` guard in `game.ts`. Left in place, unskipped, for whoever
+    // picks this back up: the body still describes the intended measurement.
+    test.fixme(true, 'the 300ms read races a formation hit around t=90ms; see task-12-report.md');
+
+    await openGame(page);
+    await page.keyboard.press('Space');
+
+    // Measured by position, not by counting elements. The shot is one static node
+    // that is shown or hidden, so its count is 1 either way and counting proves
+    // nothing. Position does: the shot the keydown fired has been climbing at
+    // 620px/s for 300ms and sits near y 190, while an autofiring build would have
+    // spawned a fresh one on the last frame, still at the muzzle near y 376.
+    //
+    // Read once rather than with a retrying matcher: after the key is released
+    // even an autofired shot flies away within 636ms, so a retrying assertion
+    // would go green by waiting.
     await page.keyboard.down('Space');
-    await page.waitForTimeout(600);
+    await page.waitForTimeout(300);
+    const y = await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>('[data-invaders-shot]');
+      if (!el || el.hidden) return null;
+      return new DOMMatrixReadOnly(getComputedStyle(el).transform).m42;
+    });
     await page.keyboard.up('Space');
-    // One shot exists in the DOM at all times and is shown or hidden. If holding
-    // autofired, the shot would have been replaced and would still be low.
-    await expect(page.locator('[data-invaders-shot]')).toHaveCount(1);
+
+    expect(y).not.toBeNull();
+    expect(y!).toBeLessThan(300);
   });
 
   test('the invaders step rather than slide', async ({ page }) => {

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
 
 /** The trigger exists above 900px on a fine pointer, and nowhere else. */
 function isDesktop(page: Page): boolean {
@@ -522,5 +523,195 @@ test.describe('the transition', () => {
 
     await page.keyboard.press('Space');
     await expect(page.locator('.invaders-invader[data-state="alive"]')).toHaveCount(45);
+  });
+});
+
+test.describe('the audits', () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(!isDesktop(page), 'the game is desktop only');
+  });
+
+  test('accent on the field is the player and nothing else', async ({ page }) => {
+    // The one colour law. Break it and the field stops being readable at a
+    // glance, which is the reason the invaders are ranked in ink steps at all.
+    await openGame(page);
+    await page.keyboard.press('Space');
+    await expect(page.locator('.invaders-invader[data-state="alive"]')).toHaveCount(45);
+
+    const offenders = await page.evaluate(() => {
+      const accent = getComputedStyle(document.documentElement)
+        .getPropertyValue('--color-accent')
+        .trim();
+      const probe = document.createElement('span');
+      probe.style.color = accent;
+      document.body.append(probe);
+      const target = getComputedStyle(probe).color;
+      probe.remove();
+
+      const field = document.querySelector('[data-invaders-field]');
+      if (!field) return ['no field'];
+
+      const found: string[] = [];
+      for (const el of field.querySelectorAll<HTMLElement>('*')) {
+        if (el.closest('[data-invaders-player]')) continue;
+        if (el.closest('[data-invaders-panel]')) continue;
+        if (el.offsetParent === null && el.tagName !== 'PRE') continue;
+        const style = getComputedStyle(el);
+        if (style.color === target || style.backgroundColor === target) {
+          found.push(`${el.tagName}.${el.className} ${style.color} / ${style.backgroundColor}`);
+        }
+      }
+      return found;
+    });
+
+    expect(offenders).toEqual([]);
+  });
+
+  test('every sprite glyph comes from Departure Mono', async ({ page }) => {
+    // The template hides the shell from glyphs.spec.ts on purpose, so the sprites
+    // need their own run with the game actually on screen.
+    await openGame(page);
+    await page.keyboard.press('Space');
+    await page.evaluate(() => document.fonts.ready);
+
+    const fallbacks = await page.evaluate(() => {
+      const probe = (ch: string) => {
+        const span = document.createElement('span');
+        span.style.cssText = 'font:100px "Departure Mono";position:absolute;visibility:hidden';
+        span.textContent = ch;
+        document.body.append(span);
+        const width = span.getBoundingClientRect().width;
+        span.remove();
+        return width;
+      };
+      const m = probe('M');
+      const root = document.querySelector<HTMLElement>('[data-invaders-root]');
+      const used = [...new Set(root?.innerText ?? '')].filter((c) => c.trim());
+      return used.filter((c) => Math.abs(probe(c) - m) > 0.5);
+    });
+
+    expect(fallbacks).toEqual([]);
+  });
+
+  test('the sprites use only a full block and a space', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+
+    const chars = await page.evaluate(() => {
+      const rows = document.querySelectorAll('.invaders-sprite div');
+      return [...new Set([...rows].map((el) => el.textContent ?? '').join(''))].sort();
+    });
+    expect(chars).toEqual([' ', '█']);
+  });
+
+  test('every sprite is one block element per row', async ({ page }) => {
+    // Newlines between inline elements are not reliable. The failure is silent:
+    // the rows fuse into one run and the sprite becomes a smear.
+    await openGame(page);
+    await page.keyboard.press('Space');
+
+    const shapes = await page.evaluate(() =>
+      [...document.querySelectorAll('.invaders-sprite')].map((pre) => ({
+        rows: pre.children.length,
+        blocks: [...pre.children].every((child) => getComputedStyle(child).display === 'block'),
+      }))
+    );
+
+    expect(shapes.length).toBeGreaterThan(45);
+    for (const shape of shapes) {
+      expect(shape.rows).toBeGreaterThanOrEqual(4);
+      expect(shape.blocks).toBe(true);
+    }
+  });
+
+  test('reads the hi score back from one namespaced key', async ({ page }) => {
+    await page.addInitScript(() =>
+      window.localStorage.setItem('bpaulino:invaders:hi', '4820')
+    );
+    await openGame(page);
+    await expect(page.locator('[data-invaders-hi]')).toHaveText('004820');
+
+    await page.keyboard.press('Escape');
+    const keys = await page.evaluate(() => Object.keys(window.localStorage));
+    expect(keys.filter((key) => key.includes('invaders'))).toEqual(['bpaulino:invaders:hi']);
+  });
+
+  test('the design token and the runtime beat agree', async ({ page }) => {
+    // --game-beat is the design system's record of the beat, and rules.ts is what
+    // the loop reads. Nothing forces them to match, so this does.
+    await openGame(page);
+    const token = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--game-beat').trim()
+    );
+    expect(token).toBe('620ms');
+  });
+
+  test('the field takes its surface from --game-field', async ({ page }) => {
+    await openGame(page);
+    const field = await page
+      .locator('[data-invaders-field]')
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(field).toBe('rgb(11, 11, 16)');
+  });
+
+  test('opens and plays with no console error', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') errors.push(message.text());
+    });
+    page.on('pageerror', (error) => errors.push(error.message));
+
+    await openGame(page);
+    await page.keyboard.press('Space');
+    await page.keyboard.down('ArrowRight');
+    await page.waitForTimeout(400);
+    await page.keyboard.up('ArrowRight');
+    await page.keyboard.press('Space');
+    await page.waitForTimeout(1200);
+    await page.keyboard.press('p');
+    await page.keyboard.press('p');
+    await page.keyboard.press('Escape');
+
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(!isDesktop(page), 'the game is desktop only');
+  });
+
+  test('axe reports no WCAG A or AA violation with the game open', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+    await page.evaluate(() => document.fonts.ready);
+
+    const { violations } = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    expect(violations.map((v) => `${v.id}: ${v.nodes.length}`)).toEqual([]);
+  });
+
+  test('is playable start to finish from the keyboard alone', async ({ page }) => {
+    await page.goto('/posts/');
+    await page.evaluate(() => document.fonts.ready);
+
+    for (let i = 0; i < 12; i += 1) {
+      await page.keyboard.press('Tab');
+      const onTrigger = await page.evaluate(
+        () => document.activeElement?.hasAttribute('data-invaders-open') === true
+      );
+      if (onTrigger) break;
+    }
+
+    await page.keyboard.press('Enter');
+    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+    await page.keyboard.press('Space');
+    await expect(page.locator('.invaders-invader[data-state="alive"]')).toHaveCount(45);
+    await page.keyboard.press('Space');
+    await expect(page.locator('[data-invaders-shot]')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
   });
 });

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import { BEAT_START } from '../../src/lib/invaders/rules';
 
 /** The trigger exists above 900px on a fine pointer, and nowhere else. */
 function isDesktop(page: Page): boolean {
@@ -537,6 +538,11 @@ test.describe('the audits', () => {
     await openGame(page);
     await page.keyboard.press('Space');
     await expect(page.locator('.invaders-invader[data-state="alive"]')).toHaveCount(45);
+    // Fire, so the shot is actually on the field when the audit runs. A hidden
+    // shot would never be inspected, and a mis-coloured shot is a defect whether
+    // or not it happens to be on screen at that instant.
+    await page.keyboard.press('Space');
+    await expect(page.locator('[data-invaders-shot]')).toBeVisible();
 
     const offenders = await page.evaluate(() => {
       const accent = getComputedStyle(document.documentElement)
@@ -554,8 +560,9 @@ test.describe('the audits', () => {
       const found: string[] = [];
       for (const el of field.querySelectorAll<HTMLElement>('*')) {
         if (el.closest('[data-invaders-player]')) continue;
+        // The panels are the only other things in the field allowed the accent:
+        // GAME OVER is drawn in it deliberately.
         if (el.closest('[data-invaders-panel]')) continue;
-        if (el.offsetParent === null && el.tagName !== 'PRE') continue;
         const style = getComputedStyle(el);
         if (style.color === target || style.backgroundColor === target) {
           found.push(`${el.tagName}.${el.className} ${style.color} / ${style.backgroundColor}`);
@@ -643,7 +650,9 @@ test.describe('the audits', () => {
     const token = await page.evaluate(() =>
       getComputedStyle(document.documentElement).getPropertyValue('--game-beat').trim()
     );
-    expect(token).toBe('620ms');
+    // The build minifies 620ms to .62s, so compare durations rather than strings.
+    const ms = token.endsWith('ms') ? Number.parseFloat(token) : Number.parseFloat(token) * 1000;
+    expect(ms).toBe(BEAT_START);
   });
 
   test('the field takes its surface from --game-field', async ({ page }) => {
@@ -652,6 +661,17 @@ test.describe('the audits', () => {
       .locator('[data-invaders-field]')
       .evaluate((el) => getComputedStyle(el).backgroundColor);
     expect(field).toBe('rgb(11, 11, 16)');
+  });
+
+  // Checks the rule shared by title, waveClear and gameOver, via the title panel,
+  // which is reachable the instant the game opens. It does not reach game over
+  // itself: that takes a real run to trigger in a browser.
+  test('a panel covers the field rather than sitting over the invaders', async ({ page }) => {
+    await openGame(page);
+    const background = await page
+      .locator('[data-invaders-panel="title"]')
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(background).toBe('rgb(11, 11, 16)');
   });
 
   test('opens and plays with no console error', async ({ page }) => {
@@ -706,7 +726,9 @@ test.describe('accessibility', () => {
     }
 
     await page.keyboard.press('Enter');
-    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+    const root = page.locator('[data-invaders-root]');
+    await expect(root).toBeVisible();
+    await expect(root).toHaveAttribute('data-armed', '');
     await page.keyboard.press('Space');
     await expect(page.locator('.invaders-invader[data-state="alive"]')).toHaveCount(45);
     await page.keyboard.press('Space');

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -331,37 +331,34 @@ test.describe('the game', () => {
   });
 
   test('holding SPACE does not autofire', async ({ page }) => {
-    // Not runnable as specified: see task-12-report.md, fix round 1, for why.
-    // In short, a wave 1 shot fired from the centre muzzle hits the centre
-    // column's bottom-rank invader around t=90ms, so `[data-invaders-shot]` is
-    // already null well before the 300ms read below, with or without the
-    // `event.repeat` guard in `game.ts`. Left in place, unskipped, for whoever
-    // picks this back up: the body still describes the intended measurement.
-    test.fixme(true, 'the 300ms read races a formation hit around t=90ms; see task-12-report.md');
-
     await openGame(page);
     await page.keyboard.press('Space');
+    await page.keyboard.press('Space');
 
-    // Measured by position, not by counting elements. The shot is one static node
-    // that is shown or hidden, so its count is 1 either way and counting proves
-    // nothing. Position does: the shot the keydown fired has been climbing at
-    // 620px/s for 300ms and sits near y 190, while an autofiring build would have
-    // spawned a fresh one on the last frame, still at the muzzle near y 376.
+    // Playwright's keyboard.down does not emit repeat keydowns, so a held key
+    // cannot reach the guard through the normal API. These synthetic events are
+    // exactly what a held key produces in a browser.
     //
-    // Read once rather than with a retrying matcher: after the key is released
-    // even an autofired shot flies away within 636ms, so a retrying assertion
-    // would go green by waiting.
-    await page.keyboard.down('Space');
-    await page.waitForTimeout(300);
-    const y = await page.evaluate(() => {
-      const el = document.querySelector<HTMLElement>('[data-invaders-shot]');
-      if (!el || el.hidden) return null;
-      return new DOMMatrixReadOnly(getComputedStyle(el).transform).m42;
+    // Position is no use as the signal either: the cannon starts centred under
+    // an occupied column, so its shot hits the bottom rank 90ms after firing.
+    // Score is the durable signal. The one real press above kills one invader
+    // for 10 points. With the guard that is the only shot ever fired, because
+    // every later event is a repeat. Without it the cannon re-arms the moment
+    // each shot clears, which is about eleven shots a second, and it eats up
+    // the centre column.
+    await page.evaluate(async () => {
+      for (let i = 0; i < 120; i += 1) {
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', { key: ' ', repeat: true, bubbles: true })
+        );
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      }
     });
-    await page.keyboard.up('Space');
 
-    expect(y).not.toBeNull();
-    expect(y!).toBeLessThan(300);
+    const score = await page.evaluate(() =>
+      Number(document.querySelector('[data-invaders-score]')?.textContent ?? '0')
+    );
+    expect(score).toBeLessThanOrEqual(10);
   });
 
   test('the invaders step rather than slide', async ({ page }) => {

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { test, expect, type Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import { BEAT_START } from '../../src/lib/invaders/rules';
@@ -450,6 +452,20 @@ test.describe('the game', () => {
     await page.keyboard.press('Escape');
     await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
   });
+
+  test('Meta+k does not raise the palette behind the game', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Meta+k');
+
+    // The game is still the one dialog in the document: the palette refused
+    // to open behind it rather than stacking a second one underneath.
+    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+    await expect(page.locator('[role="dialog"][aria-modal="true"]')).toHaveCount(1);
+
+    // No palette input exists to steal the keystroke that follows.
+    await page.keyboard.press('a');
+    await expect(page.locator('[role=combobox]')).toHaveCount(0);
+  });
 });
 
 test.describe('the transition', () => {
@@ -735,5 +751,31 @@ test.describe('accessibility', () => {
     await expect(page.locator('[data-invaders-shot]')).toBeVisible();
     await page.keyboard.press('Escape');
     await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
+  });
+});
+
+test.describe('what every page loads', () => {
+  test('the eager BaseLayout chunk carries none of the sprite art', () => {
+    // BaseLayout's inline script is the one part of the game that loads on
+    // every page (see index.ts). Minification renames identifiers but keeps
+    // string literals, so a full block glyph in this chunk is the durable
+    // sign that the sprite grids rode along with it.
+    const dir = path.join(process.cwd(), 'dist/_astro');
+    const chunkNames = fs
+      .readdirSync(dir)
+      .filter((name) => /^BaseLayout\.astro_astro_type_script_index_\d+_lang\..*\.js$/.test(name));
+    expect(chunkNames.length, `found no BaseLayout entry chunk in ${dir}`).toBeGreaterThan(0);
+
+    const offenders = chunkNames
+      .map((name) => {
+        const blocks = fs.readFileSync(path.join(dir, name), 'utf8').match(/█/g)?.length ?? 0;
+        return { name, blocks };
+      })
+      .filter((chunk) => chunk.blocks > 0);
+
+    const report = offenders
+      .map((o) => `${o.name}: ${o.blocks} block character(s)`)
+      .join(', ');
+    expect(offenders, report || undefined).toEqual([]);
   });
 });

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -112,3 +112,111 @@ test.describe('on a coarse pointer', () => {
     await expect(page.locator('[data-chrome-dot]').nth(3)).toBeVisible();
   });
 });
+
+test.describe('opening and closing', () => {
+  // The condition has to run inside a test, not at describe level: Playwright
+  // evaluates a describe-level skip before the page fixture exists.
+  test.beforeEach(async ({ page }) => {
+    test.skip(!isDesktop(page), 'the game is desktop only');
+  });
+
+  test('the dot opens the game window', async ({ page }) => {
+    await page.goto('/posts/');
+    await page.locator('[data-invaders-open]').click();
+
+    const root = page.locator('[data-invaders-root]');
+    await expect(root).toBeVisible();
+    await expect(root).toContainText('~/invaders');
+    await expect(root).toContainText('ESC EXIT');
+  });
+
+  test('holds the trigger dot white while the game is open', async ({ page }) => {
+    await page.goto('/posts/');
+    await page.locator('[data-invaders-open]').click();
+    await expect(page.locator('[data-invaders-open]')).toHaveAttribute('data-open', '');
+  });
+
+  test('typing i n v opens it too', async ({ page }) => {
+    await page.goto('/posts/');
+    await page.keyboard.press('i');
+    await page.keyboard.press('n');
+    await page.keyboard.press('v');
+    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+  });
+
+  test('i n v is ignored while the palette has focus', async ({ page }) => {
+    await page.goto('/posts/');
+    // The palette island hydrates on idle; nothing answers Meta+K until it
+    // has. palette.spec.ts's own `load` helper waits on the same signal.
+    await page.waitForSelector('astro-island[component-url*="CommandPalette"]:not([ssr])', {
+      state: 'attached',
+    });
+    await page.keyboard.press('Meta+k');
+    await expect(page.locator('[role="dialog"][aria-modal="true"]')).toBeVisible();
+
+    await page.keyboard.type('inv');
+
+    await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
+    // The letters went where they were typed.
+    await expect(page.locator('input[type="search"]')).toHaveValue('inv');
+  });
+
+  test('locks the page behind it, and does not shift it', async ({ page }) => {
+    await page.goto('/posts/');
+    const before = await page.evaluate(() => document.body.getBoundingClientRect().width);
+
+    await page.locator('[data-invaders-open]').click();
+    // openGame is behind a dynamic import; the click event fires before it
+    // resolves, so the lock is not in place until the window is visible.
+    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+
+    expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).toBe('hidden');
+    expect(await page.evaluate(() => document.body.getBoundingClientRect().width)).toBe(before);
+  });
+
+  test('Esc restores the exact scroll position', async ({ page }) => {
+    await page.goto('/entries/https-for-your-homelab/');
+    await page.evaluate(() => window.scrollTo(0, 900));
+    const before = await page.evaluate(() => window.scrollY);
+    expect(before).toBeGreaterThan(0);
+
+    // The trigger opens the game only where a real click can land, so at
+    // this scroll depth it sits off screen. Clicking it here would make
+    // Playwright's own scroll-into-view move the page before the click ever
+    // fires, which is the thing this test is trying to rule out. The `i n v`
+    // route reaches the same `openGame` without touching the scroll first.
+    await page.keyboard.press('i');
+    await page.keyboard.press('n');
+    await page.keyboard.press('v');
+    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+    await page.keyboard.press('Escape');
+
+    await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
+    expect(await page.evaluate(() => window.scrollY)).toBe(before);
+    expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe('hidden');
+  });
+
+  test('never touches the URL', async ({ page }) => {
+    await page.goto('/posts/');
+    const url = page.url();
+    const history = await page.evaluate(() => window.history.length);
+
+    await page.locator('[data-invaders-open]').click();
+    await page.keyboard.press('Escape');
+
+    expect(page.url()).toBe(url);
+    expect(await page.evaluate(() => window.history.length)).toBe(history);
+  });
+
+  test('hands focus back to the trigger on exit', async ({ page }) => {
+    await page.goto('/posts/');
+    await page.locator('[data-invaders-open]').click();
+    // openGame is behind a dynamic import; without this wait Escape can
+    // race the import and land before the game (and its listener) exists.
+    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+    await page.keyboard.press('Escape');
+    expect(
+      await page.evaluate(() => document.activeElement?.hasAttribute('data-invaders-open') === true)
+    ).toBe(true);
+  });
+});

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -237,3 +237,161 @@ test.describe('opening and closing', () => {
     ).toBe(true);
   });
 });
+
+/** Opens the game and waits for the font, which every measurement depends on. */
+async function openGame(page: Page) {
+  await page.goto('/posts/');
+  await page.evaluate(() => document.fonts.ready);
+  await page.locator('[data-invaders-open]').click();
+  await expect(page.locator('[data-invaders-root]')).toBeVisible();
+}
+
+test.describe('the game', () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(!isDesktop(page), 'the game is desktop only');
+  });
+
+  test('opens on the title screen, which is also the score table', async ({ page }) => {
+    await openGame(page);
+    const title = page.locator('[data-invaders-panel="title"]');
+    await expect(title).toBeVisible();
+    await expect(title).toContainText('INVADERS');
+    await expect(title).toContainText('PRESS SPACE TO START');
+    await expect(title).toContainText('ESC RETURNS YOU TO ~/POSTS');
+    await expect(title).toContainText('= 30 PTS');
+    await expect(title).toContainText('= 20 PTS');
+    await expect(title).toContainText('= 10 PTS');
+  });
+
+  test('SPACE starts a wave of five ranks by nine', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+
+    await expect(page.locator('[data-invaders-panel="title"]')).toBeHidden();
+    await expect(page.locator('.invaders-invader[data-state="alive"]')).toHaveCount(45);
+    await expect(page.locator('.invaders-bunker')).toHaveCount(4);
+    await expect(page.locator('[data-invaders-footer="playing"]')).toBeVisible();
+  });
+
+  test('draws the HUD and three lives as cannons, not numerals', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+
+    await expect(page.locator('[data-invaders-score]')).toHaveText('000000');
+    await expect(page.locator('[data-invaders-wave]')).toHaveText('01');
+    const lives = page.locator('[data-invaders-lives] pre');
+    await expect(lives).toHaveCount(3);
+    for (let i = 0; i < 3; i += 1) await expect(lives.nth(i)).toBeVisible();
+  });
+
+  test('puts the ground rule 24px off the bottom of a 466px field', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+
+    const geometry = await page.evaluate(() => {
+      const field = document.querySelector('[data-invaders-field]')!.getBoundingClientRect();
+      const ground = document.querySelector('[data-invaders-ground]')!.getBoundingClientRect();
+      return { fieldH: field.height, gap: field.bottom - ground.bottom };
+    });
+    expect(geometry.fieldH).toBeCloseTo(466, 0);
+    expect(geometry.gap).toBeCloseTo(24, 0);
+  });
+
+  test('the cannon moves, and stops at the wall', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+
+    const x = () =>
+      page.evaluate(
+        () => document.querySelector('[data-invaders-player]')!.getBoundingClientRect().x
+      );
+    const from = await x();
+
+    await page.keyboard.down('ArrowRight');
+    await page.waitForTimeout(250);
+    await page.keyboard.up('ArrowRight');
+    expect(await x()).toBeGreaterThan(from);
+
+    await page.keyboard.down('ArrowLeft');
+    await page.waitForTimeout(2000);
+    await page.keyboard.up('ArrowLeft');
+
+    const field = await page.evaluate(
+      () => document.querySelector('[data-invaders-field]')!.getBoundingClientRect().x
+    );
+    expect(await x()).toBeCloseTo(field, 0);
+  });
+
+  test('fires one shot, and holding SPACE does not autofire', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+
+    await page.keyboard.press('Space');
+    await expect(page.locator('[data-invaders-shot]')).toBeVisible();
+
+    await page.keyboard.down('Space');
+    await page.waitForTimeout(600);
+    await page.keyboard.up('Space');
+    // One shot exists in the DOM at all times and is shown or hidden. If holding
+    // autofired, the shot would have been replaced and would still be low.
+    await expect(page.locator('[data-invaders-shot]')).toHaveCount(1);
+  });
+
+  test('the invaders step rather than slide', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+
+    const left = () =>
+      page.evaluate(
+        () =>
+          new DOMMatrixReadOnly(
+            getComputedStyle(document.querySelector('[data-invaders-formation]')!).transform
+          ).m41
+      );
+
+    const first = await left();
+    await page.waitForTimeout(1400);
+    const later = await left();
+
+    expect(later).toBeGreaterThan(first);
+    // Two beats at 620ms is two glyph cells, about 16.5px. A tween would land
+    // on any value in between; a discrete step lands on a multiple.
+    const cell = 57.9 / 7;
+    const steps = (later - first) / cell;
+    expect(Math.abs(steps - Math.round(steps))).toBeLessThan(0.01);
+  });
+
+  test('P pauses, dims the field, and swaps the footer', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+    await page.keyboard.press('p');
+
+    await expect(page.locator('[data-invaders-panel="paused"]')).toBeVisible();
+    await expect(page.locator('[data-invaders-panel="paused"]')).toContainText('PAUSED');
+    await expect(page.locator('[data-invaders-footer="paused"]')).toContainText('P RESUME');
+    await expect(page.locator('[data-invaders-footer="playing"]')).toBeHidden();
+    await expect(page.locator('[data-invaders-field]')).toHaveAttribute('data-dim', '');
+
+    await page.keyboard.press('p');
+    await expect(page.locator('[data-invaders-panel="paused"]')).toBeHidden();
+  });
+
+  test('Esc exits from the title screen and from play', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
+
+    await page.locator('[data-invaders-open]').click();
+    await page.keyboard.press('Space');
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
+  });
+
+  test('Esc exits from pause', async ({ page }) => {
+    await openGame(page);
+    await page.keyboard.press('Space');
+    await page.keyboard.press('p');
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
+  });
+});

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -419,3 +419,72 @@ test.describe('the game', () => {
     await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
   });
 });
+
+test.describe('the transition', () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(!isDesktop(page), 'the game is desktop only');
+  });
+
+  test('covers the page with a canvas and then takes it away', async ({ page }) => {
+    await page.goto('/posts/');
+    await page.evaluate(() => document.fonts.ready);
+
+    await page.locator('[data-invaders-open]').hover();
+    await page.locator('[data-invaders-open]').click();
+
+    await expect(page.locator('[data-invaders-canvas]')).toBeVisible();
+    await expect(page.locator('[data-invaders-canvas]')).toHaveCount(0, { timeout: 4000 });
+    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+  });
+
+  test('leaves the page behind it exactly where it was', async ({ page }) => {
+    await page.goto('/entries/https-for-your-homelab/');
+    await page.evaluate(() => document.fonts.ready);
+    const before = await page.evaluate(() => ({
+      w: document.body.scrollWidth,
+      h: document.body.scrollHeight,
+    }));
+
+    await page.locator('[data-invaders-open]').click();
+    await expect(page.locator('[data-invaders-canvas]')).toBeVisible();
+    await expect(page.locator('[data-invaders-canvas]')).toHaveCount(0, { timeout: 4000 });
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-invaders-root]')).toHaveCount(0);
+
+    expect(await page.evaluate(() => ({
+      w: document.body.scrollWidth,
+      h: document.body.scrollHeight,
+    }))).toEqual(before);
+  });
+
+  test('runs no canvas at all under reduced motion', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto('/posts/');
+    await page.evaluate(() => document.fonts.ready);
+
+    await page.locator('[data-invaders-open]').click();
+
+    // Straight to the game. A canvas would mean the pixelation ran anyway.
+    await expect(page.locator('[data-invaders-root]')).toBeVisible();
+    await expect(page.locator('[data-invaders-canvas]')).toHaveCount(0);
+  });
+
+  test('the game still runs under reduced motion, and the pulse does not', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto('/posts/');
+    await page.locator('[data-invaders-open]').click();
+
+    const pulse = await page
+      .locator('.invaders-pulse')
+      .evaluate((el) => getComputedStyle(el).animationDuration);
+    expect(Number.parseFloat(pulse)).toBeLessThan(0.01);
+
+    const scan = await page
+      .locator('.invaders-scan')
+      .evaluate((el) => getComputedStyle(el).animationName);
+    expect(scan).toBe('none');
+
+    await page.keyboard.press('Space');
+    await expect(page.locator('.invaders-invader[data-state="alive"]')).toHaveCount(45);
+  });
+});

--- a/tests/e2e/motion.spec.ts
+++ b/tests/e2e/motion.spec.ts
@@ -18,12 +18,13 @@ test('reduced motion stops the scanlines', async ({ page }) => {
 });
 
 test('reduced motion pins the caret visible', async ({ page }) => {
-  // The home page's only caret is the closing prompt line's live caret
-  // (PromptLine's `caret` prop, `animate` defaulted true) — not a static
-  // size specimen, which `.caret` would also match but which reduced
-  // motion has nothing to override.
+  // The home page carries more than one .caret now: the chrome bar holds a
+  // hidden ./invaders hint caret that only shows once the game trigger is
+  // hovered. This test cares about the live prompt caret, so it selects a
+  // visible one instead of the first in DOM order. A hidden specimen has
+  // nothing for reduced motion to override.
   await page.goto('/');
-  const caret = page.locator('.caret').first();
+  const caret = page.locator('.caret:visible').first();
   await expect(caret).toBeVisible();
   // `console-blink` is `1.1s steps(1) infinite`: opacity sits at 1 for the
   // first half of every cycle regardless of reduced motion, so reading

--- a/tests/unit/invaders-bunkers.test.ts
+++ b/tests/unit/invaders-bunkers.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bunkerRect,
+  bunkerRows,
+  createBunkers,
+  erode,
+  isGone,
+  litCells,
+} from '../../src/lib/invaders/bunkers';
+import { BUNKER_COUNT, BUNKER_GAP, BUNKER_H, BUNKER_TOP, CELL_W } from '../../src/lib/invaders/rules';
+
+const FIELD_W = 1042;
+
+describe('createBunkers', () => {
+  it('makes four, each starting at 23 lit cells', () => {
+    const bunkers = createBunkers(FIELD_W);
+    expect(bunkers).toHaveLength(BUNKER_COUNT);
+    for (const b of bunkers) expect(litCells(b)).toBe(23);
+  });
+
+  it('spaces them 96px apart and centres the group', () => {
+    const bunkers = createBunkers(FIELD_W);
+    expect(bunkers[1].x - bunkers[0].x).toBeCloseTo(CELL_W + BUNKER_GAP, 5);
+
+    const groupLeft = bunkers[0].x;
+    const groupRight = bunkers[BUNKER_COUNT - 1].x + CELL_W;
+    expect(groupLeft).toBeCloseTo(FIELD_W - groupRight, 5);
+  });
+
+  it('puts them at y 352', () => {
+    const box = bunkerRect(createBunkers(FIELD_W)[0]);
+    expect(box.y).toBe(BUNKER_TOP);
+    expect(box.h).toBeCloseTo(BUNKER_H, 5);
+  });
+
+  it('gives each bunker its own cells, not a shared reference', () => {
+    const bunkers = createBunkers(FIELD_W);
+    erode(bunkers[0], bunkers[0].x + CELL_W / 2, BUNKER_TOP + 1);
+    expect(litCells(bunkers[1])).toBe(23);
+  });
+});
+
+describe('erode', () => {
+  it('clears the block of nine around the cell it hit', () => {
+    const b = createBunkers(FIELD_W)[0];
+    // The middle of row 1. Rows 0 to 2 are solid across columns 2 to 4.
+    const px = b.x + CELL_W / 2;
+    const py = BUNKER_TOP + BUNKER_H * (1.5 / 4);
+
+    expect(erode(b, px, py)).toBe(true);
+    expect(litCells(b)).toBe(23 - 9);
+  });
+
+  it('clips the block at an edge instead of wrapping', () => {
+    const b = createBunkers(FIELD_W)[0];
+    // Column 0 of row 1. The block's left column is off the grid, and row 0
+    // column 0 is already empty in the pristine sprite, so five lit cells go.
+    const px = b.x + CELL_W * 0.1;
+    const py = BUNKER_TOP + BUNKER_H * (1.5 / 4);
+
+    expect(erode(b, px, py)).toBe(true);
+    expect(litCells(b)).toBe(23 - 5);
+  });
+
+  it('does not count a second shot into the hole it already made', () => {
+    const b = createBunkers(FIELD_W)[0];
+    const px = b.x + CELL_W / 2;
+    const py = BUNKER_TOP + BUNKER_H * (1.5 / 4);
+
+    expect(erode(b, px, py)).toBe(true);
+    expect(erode(b, px, py)).toBe(false);
+    expect(litCells(b)).toBe(23 - 9);
+  });
+
+  it('reports no hit outside the sprite box', () => {
+    const b = createBunkers(FIELD_W)[0];
+    expect(erode(b, b.x - 5, BUNKER_TOP + 1)).toBe(false);
+    expect(erode(b, b.x + 1, BUNKER_TOP - 5)).toBe(false);
+    expect(litCells(b)).toBe(23);
+  });
+
+  it('reports no hit on a cell that is already clear, so a shot goes through', () => {
+    const b = createBunkers(FIELD_W)[0];
+    // Row 0 column 0 is empty in the pristine sprite.
+    const px = b.x + 1;
+    const py = BUNKER_TOP + 1;
+    expect(erode(b, px, py)).toBe(false);
+    expect(litCells(b)).toBe(23);
+  });
+
+  it('kills a bunker in five hits', () => {
+    const b = createBunkers(FIELD_W)[0];
+    // Three across the middle, then the two legs. The order matters less than
+    // the spread: firing at one spot cannot finish a bunker, because every shot
+    // after the first passes through the hole.
+    const points: [number, number][] = [
+      [0.5, 1.5],
+      [0.1, 1.5],
+      [0.9, 1.5],
+      [0.1, 3.5],
+      [0.9, 3.5],
+    ];
+    let hits = 0;
+    for (const [fx, fy] of points) {
+      if (isGone(b)) break;
+      if (erode(b, b.x + CELL_W * fx, BUNKER_TOP + BUNKER_H * (fy / 4))) hits += 1;
+    }
+    expect(hits).toBe(5);
+    expect(isGone(b)).toBe(true);
+  });
+});
+
+describe('bunkerRows', () => {
+  it('renders the pristine sprite back out', () => {
+    const b = createBunkers(FIELD_W)[0];
+    expect(bunkerRows(b)).toEqual([' █████ ', '███████', '███████', '██   ██']);
+  });
+
+  it('shows erosion as spaces, so the row stays seven cells wide', () => {
+    const b = createBunkers(FIELD_W)[0];
+    erode(b, b.x + CELL_W / 2, BUNKER_TOP + BUNKER_H * (1.5 / 4));
+    const rows = bunkerRows(b);
+    expect(rows).toHaveLength(4);
+    for (const row of rows) expect(row.length).toBe(7);
+    expect(rows.join('')).toContain(' ');
+  });
+});
+
+describe('isGone', () => {
+  it('is false while any cell is lit', () => {
+    expect(isGone(createBunkers(FIELD_W)[0])).toBe(false);
+  });
+
+  it('is true once every cell is clear', () => {
+    const b = createBunkers(FIELD_W)[0];
+    b.cells = b.cells.map((row) => row.map(() => false));
+    expect(isGone(b)).toBe(true);
+  });
+});

--- a/tests/unit/invaders-collide.test.ts
+++ b/tests/unit/invaders-collide.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { cellAt, overlaps, type Rect } from '../../src/lib/invaders/collide';
+
+const box: Rect = { x: 100, y: 200, w: 70, h: 50 };
+
+describe('overlaps', () => {
+  it('is true when two boxes share area', () => {
+    expect(overlaps(box, { x: 160, y: 240, w: 20, h: 20 })).toBe(true);
+  });
+
+  it('is false when they only touch on an edge', () => {
+    // Touching is not a hit. A shot resting exactly on an invader's top edge
+    // has not reached it yet, and counting it would kill on the frame before
+    // the sprites visibly meet.
+    expect(overlaps(box, { x: 170, y: 200, w: 10, h: 10 })).toBe(false);
+    expect(overlaps(box, { x: 100, y: 250, w: 10, h: 10 })).toBe(false);
+  });
+
+  it('is false when they are apart', () => {
+    expect(overlaps(box, { x: 0, y: 0, w: 10, h: 10 })).toBe(false);
+  });
+
+  it('is true when one box contains the other', () => {
+    expect(overlaps(box, { x: 110, y: 210, w: 5, h: 5 })).toBe(true);
+  });
+});
+
+describe('cellAt', () => {
+  it('maps a point to its grid cell', () => {
+    // 70 wide over 7 columns is 10px a column. 50 tall over 5 rows is 10px a row.
+    expect(cellAt(box, 7, 5, 105, 205)).toEqual({ col: 0, row: 0 });
+    expect(cellAt(box, 7, 5, 165, 245)).toEqual({ col: 6, row: 4 });
+    expect(cellAt(box, 7, 5, 135, 225)).toEqual({ col: 3, row: 2 });
+  });
+
+  it('returns null outside the box', () => {
+    expect(cellAt(box, 7, 5, 99, 205)).toBeNull();
+    expect(cellAt(box, 7, 5, 105, 199)).toBeNull();
+    expect(cellAt(box, 7, 5, 170, 205)).toBeNull();
+    expect(cellAt(box, 7, 5, 105, 250)).toBeNull();
+  });
+
+  it('never reports a cell past the last one', () => {
+    // Floating point on the right edge is the failure this guards: a point a
+    // hair inside 170 must land in column 6, not column 7.
+    const cell = cellAt(box, 7, 5, 169.999, 249.999);
+    expect(cell).toEqual({ col: 6, row: 4 });
+  });
+});

--- a/tests/unit/invaders-collide.test.ts
+++ b/tests/unit/invaders-collide.test.ts
@@ -40,10 +40,22 @@ describe('cellAt', () => {
     expect(cellAt(box, 7, 5, 105, 250)).toBeNull();
   });
 
-  it('never reports a cell past the last one', () => {
-    // Floating point on the right edge is the failure this guards: a point a
-    // hair inside 170 must land in column 6, not column 7.
+  it('keeps a point just inside the right edge in the last cell', () => {
     const cell = cellAt(box, 7, 5, 169.999, 249.999);
     expect(cell).toEqual({ col: 6, row: 4 });
+  });
+
+  it('clamps a column that the subtraction rounds past the last one', () => {
+    // The real reason the clamp exists, and it needs these values rather than
+    // round ones. `px - x` can round up to exactly `w` while `px < x + w`, which
+    // makes the unclamped index equal `cols` and read off the end of a sprite
+    // grid. No double between 100 and 170 reaches that case, so the test above
+    // passes whether the clamp is there or not.
+    const drift: Rect = { x: 104.86599972550059, y: 0, w: 387.3766972172531, h: 10 };
+    const px = 492.24269694275364;
+
+    expect(px).toBeLessThan(drift.x + drift.w);
+    expect(Math.floor(((px - drift.x) / drift.w) * 32)).toBe(32);
+    expect(cellAt(drift, 32, 5, px, 5)).toEqual({ col: 31, row: 2 });
   });
 });

--- a/tests/unit/invaders-formation.test.ts
+++ b/tests/unit/invaders-formation.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import {
+  alive,
+  clearBursts,
+  createFormation,
+  formationBottom,
+  invaderRect,
+  killInvader,
+  lowestInColumn,
+  occupiedColumns,
+  stepFormation,
+} from '../../src/lib/invaders/formation';
+import {
+  BEAT_START,
+  BURST_MS,
+  CELL_W,
+  COLUMNS,
+  COLUMN_PITCH,
+  DESCENT,
+  FORMATION_H,
+  RANKS,
+  RANK_PITCH,
+  STEP_X,
+} from '../../src/lib/invaders/rules';
+
+const FIELD_W = 1042;
+
+describe('createFormation', () => {
+  it('builds 45 live invaders, five ranks of nine', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    expect(f.invaders).toHaveLength(RANKS * COLUMNS);
+    expect(alive(f)).toHaveLength(RANKS * COLUMNS);
+    expect(new Set(f.invaders.map((i) => i.rank)).size).toBe(RANKS);
+  });
+
+  it('centres the block and starts it moving right', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    expect(f.left).toBeCloseTo(180.45, 2);
+    expect(f.dir).toBe(1);
+  });
+
+  it('schedules the first beat one beat out', () => {
+    const f = createFormation(1, FIELD_W, 500);
+    expect(f.nextBeatAt).toBe(500 + BEAT_START);
+  });
+
+  it('starts a later wave lower and with a lower beat floor', () => {
+    const one = createFormation(1, FIELD_W, 0);
+    const two = createFormation(2, FIELD_W, 0);
+    expect(two.top).toBeCloseTo(one.top + RANK_PITCH, 5);
+    expect(two.beatFloor).toBeLessThan(one.beatFloor);
+  });
+});
+
+describe('invaderRect', () => {
+  it('places an invader by its rank and column pitch', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    const inv = f.invaders.find((i) => i.rank === 2 && i.col === 3)!;
+    const box = invaderRect(f, inv);
+    expect(box.x).toBeCloseTo(f.left + 3 * COLUMN_PITCH, 5);
+    expect(box.y).toBeCloseTo(f.top + 2 * RANK_PITCH, 5);
+    expect(box.w).toBeCloseTo(CELL_W, 5);
+  });
+});
+
+describe('stepFormation', () => {
+  it('does nothing before the beat is due', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    const left = f.left;
+    expect(stepFormation(f, BEAT_START - 1, FIELD_W)).toBe(false);
+    expect(f.left).toBe(left);
+  });
+
+  it('jumps one glyph cell on the beat, with no tween', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    const left = f.left;
+    expect(stepFormation(f, BEAT_START, FIELD_W)).toBe(true);
+    expect(f.left).toBeCloseTo(left + STEP_X, 5);
+  });
+
+  it('alternates the sprite frame on every step', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    expect(f.frame).toBe('a');
+    stepFormation(f, BEAT_START, FIELD_W);
+    expect(f.frame).toBe('b');
+    stepFormation(f, BEAT_START * 2, FIELD_W);
+    expect(f.frame).toBe('a');
+  });
+
+  it('drops 16px and reverses on touching a wall, and does not also move', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    // Park the block one step short of the right wall.
+    f.left = FIELD_W - (COLUMNS - 1) * COLUMN_PITCH - CELL_W;
+    const top = f.top;
+    const left = f.left;
+
+    stepFormation(f, BEAT_START, FIELD_W);
+
+    expect(f.dir).toBe(-1);
+    expect(f.top).toBeCloseTo(top + DESCENT, 5);
+    expect(f.left).toBeCloseTo(left, 5);
+  });
+
+  it('measures the wall against living columns, not the original nine', () => {
+    // With the right three columns dead the block can travel further before it
+    // turns. Reading the wall off the starting width would turn it early and
+    // leave a visible gap at the edge.
+    const f = createFormation(1, FIELD_W, 0);
+    for (const inv of f.invaders) if (inv.col >= COLUMNS - 3) inv.alive = false;
+    f.left = FIELD_W - (COLUMNS - 1) * COLUMN_PITCH - CELL_W;
+    const top = f.top;
+
+    stepFormation(f, BEAT_START, FIELD_W);
+
+    expect(f.dir).toBe(1);
+    expect(f.top).toBe(top);
+  });
+
+  it('shortens the beat as invaders die, down to the floor', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    stepFormation(f, BEAT_START, FIELD_W);
+    const firstGap = f.nextBeatAt - BEAT_START;
+
+    for (const inv of f.invaders.slice(0, 10)) killInvader(f, inv, 0);
+    stepFormation(f, f.nextBeatAt, FIELD_W);
+    const laterGap = f.nextBeatAt - (BEAT_START + firstGap);
+
+    expect(laterGap).toBeLessThan(firstGap);
+    expect(laterGap).toBeGreaterThanOrEqual(f.beatFloor);
+  });
+});
+
+describe('killInvader', () => {
+  it('scores the rank and starts the burst', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    const top = f.invaders.find((i) => i.rank === 0)!;
+    expect(killInvader(f, top, 1000)).toBe(30);
+    expect(top.alive).toBe(false);
+    expect(top.burstUntil).toBe(1000 + BURST_MS);
+    expect(f.kills).toBe(1);
+  });
+
+  it('scores 20 for the middle ranks and 10 for the bottom two', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    expect(killInvader(f, f.invaders.find((i) => i.rank === 1)!, 0)).toBe(20);
+    expect(killInvader(f, f.invaders.find((i) => i.rank === 2)!, 0)).toBe(20);
+    expect(killInvader(f, f.invaders.find((i) => i.rank === 3)!, 0)).toBe(10);
+    expect(killInvader(f, f.invaders.find((i) => i.rank === 4)!, 0)).toBe(10);
+  });
+
+  it('drops the invader out of the living set', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    killInvader(f, f.invaders[0], 0);
+    expect(alive(f)).toHaveLength(RANKS * COLUMNS - 1);
+  });
+});
+
+describe('clearBursts', () => {
+  it('leaves the burst up for 110ms and then takes it down', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    const inv = f.invaders[0];
+    killInvader(f, inv, 1000);
+
+    clearBursts(f, 1000 + BURST_MS - 1);
+    expect(inv.burstUntil).toBe(1000 + BURST_MS);
+
+    clearBursts(f, 1000 + BURST_MS);
+    expect(inv.burstUntil).toBe(0);
+  });
+});
+
+describe('picking a column to bomb', () => {
+  it('lists only columns that still hold something', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    for (const inv of f.invaders) if (inv.col === 4) inv.alive = false;
+    expect(occupiedColumns(f)).not.toContain(4);
+    expect(occupiedColumns(f)).toHaveLength(COLUMNS - 1);
+  });
+
+  it('finds the lowest living invader in a column', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    expect(lowestInColumn(f, 2)!.rank).toBe(RANKS - 1);
+
+    for (const inv of f.invaders) if (inv.col === 2 && inv.rank >= 3) inv.alive = false;
+    expect(lowestInColumn(f, 2)!.rank).toBe(2);
+  });
+
+  it('returns null for an empty column', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    for (const inv of f.invaders) if (inv.col === 0) inv.alive = false;
+    expect(lowestInColumn(f, 0)).toBeNull();
+  });
+});
+
+describe('formationBottom', () => {
+  it('is the bottom edge of the lowest living rank', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    expect(formationBottom(f)).toBeCloseTo(f.top + FORMATION_H, 5);
+  });
+
+  it('rises as the bottom ranks are cleared', () => {
+    const f = createFormation(1, FIELD_W, 0);
+    for (const inv of f.invaders) if (inv.rank === RANKS - 1) inv.alive = false;
+    expect(formationBottom(f)).toBeCloseTo(f.top + FORMATION_H - RANK_PITCH, 5);
+  });
+});

--- a/tests/unit/invaders-projectiles.test.ts
+++ b/tests/unit/invaders-projectiles.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  advanceBombs,
+  advanceShot,
+  bombRect,
+  shotRect,
+  type Bomb,
+} from '../../src/lib/invaders/projectiles';
+import { BOMB_H, BOMB_SPEED, FIELD_H, SHOT_H, SHOT_SPEED, SHOT_W } from '../../src/lib/invaders/rules';
+
+describe('shotRect', () => {
+  it('is 3 by 19 at the shot position', () => {
+    expect(shotRect({ x: 100, y: 200 })).toEqual({ x: 100, y: 200, w: SHOT_W, h: SHOT_H });
+  });
+});
+
+describe('advanceShot', () => {
+  it('travels up at 620px a second', () => {
+    const moved = advanceShot({ x: 10, y: 400 }, 1000);
+    expect(moved!.y).toBeCloseTo(400 - SHOT_SPEED, 5);
+    expect(moved!.x).toBe(10);
+  });
+
+  it('scales with the frame time', () => {
+    const moved = advanceShot({ x: 0, y: 400 }, 16);
+    expect(moved!.y).toBeCloseTo(400 - SHOT_SPEED * 0.016, 5);
+  });
+
+  it('is gone once it leaves the top of the field', () => {
+    expect(advanceShot({ x: 0, y: 5 }, 1000)).toBeNull();
+  });
+
+  it('is still there while any of it is on the field', () => {
+    expect(advanceShot({ x: 0, y: SHOT_H - 1 }, 0)).not.toBeNull();
+  });
+
+  it('passes null straight through, so a frame with no shot is free', () => {
+    expect(advanceShot(null, 16)).toBeNull();
+  });
+});
+
+describe('advanceBombs', () => {
+  const bombs: Bomb[] = [
+    { x: 10, y: 100, rank: 0 },
+    { x: 20, y: 200, rank: 4 },
+  ];
+
+  it('travels down at 210px a second and keeps the source rank', () => {
+    const moved = advanceBombs(bombs, 1000);
+    expect(moved[0].y).toBeCloseTo(100 + BOMB_SPEED, 5);
+    expect(moved[0].rank).toBe(0);
+    expect(moved[1].rank).toBe(4);
+  });
+
+  it('drops the ones that have left the bottom of the field', () => {
+    const moved = advanceBombs([{ x: 0, y: FIELD_H - 1, rank: 0 }], 1000);
+    expect(moved).toHaveLength(0);
+  });
+
+  it('does not mutate the array it was given', () => {
+    const original = [{ x: 0, y: 0, rank: 0 }];
+    advanceBombs(original, 1000);
+    expect(original[0].y).toBe(0);
+  });
+
+  it('is empty in, empty out', () => {
+    expect(advanceBombs([], 16)).toEqual([]);
+  });
+});
+
+describe('bombRect', () => {
+  it('is 3 by 15 at the bomb position', () => {
+    expect(bombRect({ x: 5, y: 6, rank: 2 })).toEqual({ x: 5, y: 6, w: 3, h: BOMB_H });
+  });
+});

--- a/tests/unit/invaders-projectiles.test.ts
+++ b/tests/unit/invaders-projectiles.test.ts
@@ -16,8 +16,11 @@ describe('shotRect', () => {
 
 describe('advanceShot', () => {
   it('travels up at 620px a second', () => {
-    const moved = advanceShot({ x: 10, y: 400 }, 1000);
-    expect(moved!.y).toBeCloseTo(400 - SHOT_SPEED, 5);
+    // Measured over a tenth of a second and scaled. A full second of travel
+    // needs a start above y 601, and the field is only 466 tall, so the shot
+    // would already be gone and there would be nothing to measure.
+    const moved = advanceShot({ x: 10, y: 400 }, 100);
+    expect(moved!.y).toBeCloseTo(400 - SHOT_SPEED / 10, 5);
     expect(moved!.x).toBe(10);
   });
 

--- a/tests/unit/invaders-rules.test.ts
+++ b/tests/unit/invaders-rules.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BEAT_DECAY,
+  BEAT_FLOOR,
+  BEAT_START,
+  CELL_H,
+  CELL_W,
+  COLUMNS,
+  COLUMN_PITCH,
+  FIELD_H,
+  FORMATION_H,
+  FORMATION_TOP,
+  FORMATION_W,
+  LIVES,
+  MAX_BOMBS,
+  PLAYER_H,
+  PLAYER_TOP,
+  RANKS,
+  RANK_PITCH,
+  SCORES,
+  STEP_X,
+  beatFloorFor,
+  beatFor,
+  clampPlayerX,
+  formationLeftFor,
+  formationTopFor,
+} from '../../src/lib/invaders/rules';
+
+describe('measured geometry', () => {
+  it('matches the handoff formation', () => {
+    expect(RANKS).toBe(5);
+    expect(COLUMNS).toBe(9);
+    expect(CELL_W).toBeCloseTo(57.9, 5);
+    expect(CELL_H).toBeCloseTo(46.8, 5);
+    expect(COLUMN_PITCH).toBeCloseTo(77.9, 5);
+    expect(RANK_PITCH).toBeCloseTo(61.8, 5);
+  });
+
+  it('derives a formation 681.1 by 294 from the pitches', () => {
+    expect(FORMATION_W).toBeCloseTo(681.1, 5);
+    expect(FORMATION_H).toBeCloseTo(294, 5);
+  });
+
+  it('places wave one where the handoff says: y 26 to 320', () => {
+    expect(FORMATION_TOP).toBe(26);
+    expect(FORMATION_TOP + FORMATION_H).toBeCloseTo(320, 5);
+  });
+
+  it('steps one glyph cell per beat, not one sprite', () => {
+    expect(STEP_X).toBeCloseTo(57.9 / 7, 5);
+  });
+});
+
+describe('formationLeftFor', () => {
+  // The field width is fluid, so the formation is centred rather than placed at
+  // a fixed x. The handoff's origin of 180.4 at a 1042px field is what proves
+  // it: that number is exactly half the leftover.
+  it('reproduces the handoff origin at the reference width', () => {
+    expect(formationLeftFor(1042)).toBeCloseTo(180.45, 2);
+  });
+
+  it('keeps the formation on the field at the 900px trigger floor', () => {
+    // 900 viewport, less p-7 either side, less the 1px border either side.
+    const narrowest = 900 - 56 - 2;
+    expect(formationLeftFor(narrowest)).toBeGreaterThan(0);
+  });
+});
+
+describe('formationTopFor', () => {
+  it('starts wave one at the measured top', () => {
+    expect(formationTopFor(1)).toBe(26);
+  });
+
+  it('starts wave two one rank lower', () => {
+    expect(formationTopFor(2)).toBeCloseTo(26 + 61.8, 5);
+  });
+
+  // The field is 466px and the formation is 294px, so there is 74.56px between
+  // the formation's bottom row and the top of the player. One rank pitch is
+  // 61.8px, so exactly one wave of drop fits. After that only the beat floor
+  // carries the difficulty. This cap is a consequence of the handoff's own
+  // measurements, not a choice.
+  it('holds there, because a second rank would reach the player', () => {
+    expect(formationTopFor(3)).toEqual(formationTopFor(2));
+    expect(formationTopFor(9)).toEqual(formationTopFor(2));
+  });
+
+  it('leaves the bottom rank clear of the player at every wave', () => {
+    for (const wave of [1, 2, 3, 7]) {
+      expect(formationTopFor(wave) + FORMATION_H).toBeLessThan(PLAYER_TOP);
+    }
+  });
+});
+
+describe('beatFor', () => {
+  it('starts at 620ms', () => {
+    expect(beatFor(0)).toBe(BEAT_START);
+  });
+
+  it('shortens 6 percent per kill', () => {
+    expect(beatFor(1)).toBeCloseTo(BEAT_START * BEAT_DECAY, 5);
+    expect(beatFor(2)).toBeCloseTo(BEAT_START * BEAT_DECAY ** 2, 5);
+  });
+
+  it('never goes under the floor', () => {
+    expect(beatFor(1000)).toBe(BEAT_FLOOR);
+  });
+
+  it('takes a lower floor for later waves', () => {
+    expect(beatFor(1000, 50)).toBe(50);
+  });
+
+  it('pins to the floor before the formation is cleared', () => {
+    // 45 invaders exist. If the floor only bound after the last kill the beat
+    // would never actually reach it.
+    expect(beatFor(RANKS * COLUMNS - 1)).toBe(BEAT_FLOOR);
+  });
+});
+
+describe('beatFloorFor', () => {
+  it('is the base floor on wave one', () => {
+    expect(beatFloorFor(1)).toBe(BEAT_FLOOR);
+  });
+
+  it('drops 10ms a wave', () => {
+    expect(beatFloorFor(2)).toBe(80);
+    expect(beatFloorFor(4)).toBe(60);
+  });
+
+  it('stops at 50ms', () => {
+    expect(beatFloorFor(5)).toBe(50);
+    expect(beatFloorFor(20)).toBe(50);
+  });
+});
+
+describe('clampPlayerX', () => {
+  it('holds the whole cannon on the field', () => {
+    expect(clampPlayerX(-50, 1042)).toBe(0);
+    expect(clampPlayerX(5000, 1042)).toBeCloseTo(1042 - CELL_W, 5);
+  });
+
+  it('leaves a legal position alone', () => {
+    expect(clampPlayerX(300, 1042)).toBe(300);
+  });
+});
+
+describe('the rest of the table', () => {
+  it('scores each rank by its band', () => {
+    expect(SCORES).toEqual([30, 20, 20, 10, 10]);
+  });
+
+  it('gives three lives and at most three bombs', () => {
+    expect(LIVES).toBe(3);
+    expect(MAX_BOMBS).toBe(3);
+  });
+
+  it('puts the player 34px off the bottom of a 466px field', () => {
+    expect(FIELD_H).toBe(466);
+    expect(PLAYER_TOP).toBeCloseTo(FIELD_H - 34 - PLAYER_H, 5);
+  });
+});

--- a/tests/unit/invaders-sprites.test.ts
+++ b/tests/unit/invaders-sprites.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BUNKER,
+  BURST,
+  CRAB,
+  OCTOPUS,
+  PLAYER,
+  RANK_INK,
+  RANK_SPRITE,
+  SPRITE_COLS,
+  SQUID,
+  gridCells,
+  type Grid,
+} from '../../src/lib/invaders/sprites';
+
+const ALL: Record<string, Grid> = {
+  'squid frame a': SQUID.a,
+  'squid frame b': SQUID.b,
+  'crab frame a': CRAB.a,
+  'crab frame b': CRAB.b,
+  'octopus frame a': OCTOPUS.a,
+  'octopus frame b': OCTOPUS.b,
+  burst: BURST,
+  player: PLAYER,
+  bunker: BUNKER,
+};
+
+describe('every grid', () => {
+  for (const [name, grid] of Object.entries(ALL)) {
+    it(`${name} is ${SPRITE_COLS} cells wide on every row`, () => {
+      for (const row of grid) expect(row.length).toBe(SPRITE_COLS);
+    });
+
+    it(`${name} is built only from a full block and a space`, () => {
+      const chars = new Set(grid.join(''));
+      expect([...chars].sort()).toEqual([' ', '█']);
+    });
+
+    it(`${name} has at least one lit cell on every row`, () => {
+      for (const row of grid) expect(row).toContain('█');
+    });
+  }
+});
+
+describe('heights', () => {
+  it('invaders and the burst are 5 rows', () => {
+    expect(SQUID.a).toHaveLength(5);
+    expect(CRAB.a).toHaveLength(5);
+    expect(OCTOPUS.a).toHaveLength(5);
+    expect(BURST).toHaveLength(5);
+  });
+
+  it('the player and the bunker are 4 rows', () => {
+    expect(PLAYER).toHaveLength(4);
+    expect(BUNKER).toHaveLength(4);
+  });
+});
+
+describe('frame b differs from frame a', () => {
+  // The beat is only legible because the sprite changes on every step. A pair
+  // that drifted into being identical would still render, and nothing else in
+  // the suite would notice.
+  it('on all three ranks', () => {
+    expect(SQUID.b).not.toEqual(SQUID.a);
+    expect(CRAB.b).not.toEqual(CRAB.a);
+    expect(OCTOPUS.b).not.toEqual(OCTOPUS.a);
+  });
+});
+
+describe('rank tables', () => {
+  it('map five ranks to three sprites, by score band', () => {
+    expect(RANK_SPRITE).toEqual([SQUID, CRAB, CRAB, OCTOPUS, OCTOPUS]);
+  });
+
+  it('rank the invaders in ink steps, never in colour', () => {
+    expect(RANK_INK).toEqual([
+      '--color-ink-muted',
+      '--color-ink-secondary',
+      '--color-ink-secondary',
+      '--color-ink-body',
+      '--color-ink-body',
+    ]);
+  });
+});
+
+describe('gridCells', () => {
+  it('turns a grid into a row major boolean matrix', () => {
+    expect(gridCells([' █ ', '███'])).toEqual([
+      [false, true, false],
+      [true, true, true],
+    ]);
+  });
+
+  it('counts the bunker at 23 lit cells', () => {
+    const lit = gridCells(BUNKER).flat().filter(Boolean).length;
+    expect(lit).toBe(23);
+  });
+});

--- a/tests/unit/invaders-state.test.ts
+++ b/tests/unit/invaders-state.test.ts
@@ -1,0 +1,371 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  createGame,
+  deathFor,
+  playerRect,
+  startGame,
+  step,
+  togglePause,
+  type GameState,
+  type Input,
+} from '../../src/lib/invaders/state';
+import { alive, invaderRect } from '../../src/lib/invaders/formation';
+import { litCells } from '../../src/lib/invaders/bunkers';
+import {
+  BOMB_H,
+  CELL_H,
+  CELL_W,
+  GROUND_Y,
+  HIT_FLASH_MS,
+  LIVES,
+  MAX_BOMBS,
+  PLAYER_SPEED,
+  PLAYER_TOP,
+  RANKS,
+  RESPAWN_MS,
+  WAVE_CLEAR_MS,
+} from '../../src/lib/invaders/rules';
+
+const FIELD_W = 1042;
+const IDLE: Input = { left: false, right: false, fire: false };
+
+/** An rng that reads from a queue and then repeats its last value. */
+function queued(values: number[]): () => number {
+  let i = 0;
+  return () => values[Math.min(i++, values.length - 1)];
+}
+
+const NEVER_BOMB = () => 0.99;
+const ALWAYS_BOMB = () => 0;
+
+let game: GameState;
+
+beforeEach(() => {
+  game = createGame(4820, FIELD_W);
+});
+
+describe('createGame', () => {
+  it('opens on the title screen with the stored hi score', () => {
+    expect(game.phase).toBe('title');
+    expect(game.hi).toBe(4820);
+    expect(game.score).toBe(0);
+    expect(game.wave).toBe(1);
+    expect(game.lives).toBe(LIVES);
+  });
+
+  it('centres the cannon', () => {
+    expect(game.playerX).toBeCloseTo((FIELD_W - CELL_W) / 2, 5);
+  });
+
+  it('does not run until it is started', () => {
+    const before = game.formation.left;
+    step(game, 5000, IDLE, NEVER_BOMB);
+    expect(game.formation.left).toBe(before);
+    expect(game.now).toBe(0);
+  });
+});
+
+describe('startGame', () => {
+  it('moves to playing and clears the last run', () => {
+    game.score = 900;
+    game.wave = 4;
+    game.lives = 1;
+    startGame(game);
+    expect(game.phase).toBe('playing');
+    expect(game.score).toBe(0);
+    expect(game.wave).toBe(1);
+    expect(game.lives).toBe(LIVES);
+    expect(game.death).toBeNull();
+  });
+
+  it('keeps the hi score, which outlives the run', () => {
+    startGame(game);
+    expect(game.hi).toBe(4820);
+  });
+});
+
+describe('the player', () => {
+  beforeEach(() => startGame(game));
+
+  it('moves smoothly at 380px a second', () => {
+    const from = game.playerX;
+    step(game, 1000, { left: false, right: true, fire: false }, NEVER_BOMB);
+    expect(game.playerX).toBeCloseTo(from + PLAYER_SPEED, 5);
+  });
+
+  it('stays on the field', () => {
+    for (let i = 0; i < 20; i += 1) {
+      step(game, 100, { left: true, right: false, fire: false }, NEVER_BOMB);
+    }
+    expect(game.playerX).toBe(0);
+  });
+
+  it('does not move when both directions are held', () => {
+    const from = game.playerX;
+    step(game, 100, { left: true, right: true, fire: false }, NEVER_BOMB);
+    expect(game.playerX).toBe(from);
+  });
+});
+
+describe('firing', () => {
+  beforeEach(() => startGame(game));
+
+  it('puts one shot in flight, centred on the cannon', () => {
+    step(game, 16, { ...IDLE, fire: true }, NEVER_BOMB);
+    expect(game.shot).not.toBeNull();
+    expect(game.shot!.x).toBeCloseTo(game.playerX + CELL_W / 2 - 1.5, 5);
+    expect(game.shot!.y).toBeLessThanOrEqual(PLAYER_TOP);
+  });
+
+  it('refuses a second shot while the first is in flight', () => {
+    step(game, 16, { ...IDLE, fire: true }, NEVER_BOMB);
+    const first = game.shot;
+    step(game, 16, { ...IDLE, fire: true }, NEVER_BOMB);
+    expect(game.shot!.y).toBeLessThan(first!.y);
+    expect(game.shot!.x).toBe(first!.x);
+  });
+
+  it('allows the next shot once the first has left the field', () => {
+    step(game, 16, { ...IDLE, fire: true }, NEVER_BOMB);
+    step(game, 2000, IDLE, NEVER_BOMB);
+    expect(game.shot).toBeNull();
+    step(game, 16, { ...IDLE, fire: true }, NEVER_BOMB);
+    expect(game.shot).not.toBeNull();
+  });
+});
+
+describe('killing an invader', () => {
+  beforeEach(() => startGame(game));
+
+  it('scores it, removes it, and takes the shot with it', () => {
+    // Put the shot just under the bottom rank of the middle column.
+    const target = game.formation.invaders.find((i) => i.rank === RANKS - 1 && i.col === 4)!;
+    const box = invaderRect(game.formation, target);
+    game.shot = { x: box.x + CELL_W / 2, y: box.y + box.h - 1 };
+
+    step(game, 16, IDLE, NEVER_BOMB);
+
+    expect(target.alive).toBe(false);
+    expect(game.score).toBe(10);
+    expect(game.shot).toBeNull();
+  });
+
+  it('lifts the hi score once the run passes it', () => {
+    game.score = 4815;
+    const target = game.formation.invaders.find((i) => i.rank === 0 && i.col === 4)!;
+    const box = invaderRect(game.formation, target);
+    game.shot = { x: box.x + CELL_W / 2, y: box.y + box.h - 1 };
+
+    step(game, 16, IDLE, NEVER_BOMB);
+
+    expect(game.score).toBe(4845);
+    expect(game.hi).toBe(4845);
+  });
+});
+
+describe('bombs', () => {
+  beforeEach(() => startGame(game));
+
+  it('drops from the lowest invader in the chosen column', () => {
+    // First rng call passes the chance, second picks column index 0.
+    step(game, game.formation.nextBeatAt + 1, IDLE, queued([0, 0]));
+    expect(game.bombs).toHaveLength(1);
+
+    const lowest = game.formation.invaders.find((i) => i.rank === RANKS - 1 && i.col === 0)!;
+    const box = invaderRect(game.formation, lowest);
+    expect(game.bombs[0].x).toBeCloseTo(box.x + CELL_W / 2 - 1.5, 5);
+    expect(game.bombs[0].y).toBeCloseTo(box.y + CELL_H, 5);
+    expect(game.bombs[0].rank).toBe(RANKS - 1);
+  });
+
+  it('never has more than three falling', () => {
+    for (let i = 0; i < 12; i += 1) {
+      step(game, game.formation.nextBeatAt - game.now + 1, IDLE, ALWAYS_BOMB);
+    }
+    expect(game.bombs.length).toBeLessThanOrEqual(MAX_BOMBS);
+  });
+
+  it('drops none when the chance does not pass', () => {
+    for (let i = 0; i < 5; i += 1) {
+      step(game, game.formation.nextBeatAt - game.now + 1, IDLE, NEVER_BOMB);
+    }
+    expect(game.bombs).toHaveLength(0);
+  });
+
+  it('only drops on a beat, not on every frame', () => {
+    step(game, 16, IDLE, ALWAYS_BOMB);
+    expect(game.bombs).toHaveLength(0);
+  });
+});
+
+describe('taking a hit', () => {
+  beforeEach(() => startGame(game));
+
+  /** Parks a bomb one frame above the cannon. */
+  function bombOnPlayer(g: GameState) {
+    g.bombs = [{ x: g.playerX + CELL_W / 2, y: PLAYER_TOP - BOMB_H + 1, rank: 0 }];
+  }
+
+  it('costs a life, flashes the field and starts the respawn', () => {
+    bombOnPlayer(game);
+    step(game, 16, IDLE, NEVER_BOMB);
+
+    expect(game.lives).toBe(LIVES - 1);
+    expect(game.hitUntil).toBe(game.now + HIT_FLASH_MS);
+    expect(game.respawnUntil).toBe(game.now + RESPAWN_MS);
+    expect(game.bombs).toHaveLength(0);
+  });
+
+  it('will not let a respawning cannon fire', () => {
+    bombOnPlayer(game);
+    step(game, 16, IDLE, NEVER_BOMB);
+    step(game, 16, { ...IDLE, fire: true }, NEVER_BOMB);
+    expect(game.shot).toBeNull();
+  });
+
+  it('lets a respawning cannon still move', () => {
+    bombOnPlayer(game);
+    step(game, 16, IDLE, NEVER_BOMB);
+    const from = game.playerX;
+    step(game, 100, { ...IDLE, right: true }, NEVER_BOMB);
+    expect(game.playerX).toBeGreaterThan(from);
+  });
+
+  it('cannot be hit again while respawning', () => {
+    bombOnPlayer(game);
+    step(game, 16, IDLE, NEVER_BOMB);
+    bombOnPlayer(game);
+    step(game, 16, IDLE, NEVER_BOMB);
+    expect(game.lives).toBe(LIVES - 1);
+  });
+
+  it('ends the game on the third loss, and records what killed you', () => {
+    for (let i = 0; i < LIVES; i += 1) {
+      game.respawnUntil = 0;
+      bombOnPlayer(game);
+      step(game, 16, IDLE, NEVER_BOMB);
+    }
+    expect(game.lives).toBe(0);
+    expect(game.phase).toBe('gameOver');
+    expect(game.death).toEqual({ rank: 1, row: RANKS });
+  });
+});
+
+describe('deathFor', () => {
+  // The handoff's line is "killed by rank-1 invader at row 5". Rank counts from
+  // the top by score, row counts from the bottom of the formation, which is the
+  // only reading where rank 1 and row 5 describe the same invader.
+  it('numbers the top rank as rank 1 in row 5', () => {
+    expect(deathFor(0)).toEqual({ rank: 1, row: 5 });
+  });
+
+  it('numbers the bottom rank as rank 5 in row 1', () => {
+    expect(deathFor(RANKS - 1)).toEqual({ rank: 5, row: 1 });
+  });
+});
+
+describe('bombs against bunkers', () => {
+  beforeEach(() => startGame(game));
+
+  it('erode the bunker and stop the bomb', () => {
+    const bunker = game.bunkers[0];
+    const before = litCells(bunker);
+    game.bombs = [{ x: bunker.x + CELL_W / 2, y: 352 - BOMB_H + 1, rank: 0 }];
+
+    step(game, 16, IDLE, NEVER_BOMB);
+
+    expect(litCells(bunker)).toBeLessThan(before);
+    expect(game.bombs).toHaveLength(0);
+  });
+});
+
+describe('the ground line', () => {
+  beforeEach(() => startGame(game));
+
+  it('ends the game when the lowest rank reaches it', () => {
+    game.formation.top = GROUND_Y;
+    step(game, game.formation.nextBeatAt + 1, IDLE, NEVER_BOMB);
+    expect(game.phase).toBe('gameOver');
+    expect(game.death).not.toBeNull();
+  });
+});
+
+describe('clearing a wave', () => {
+  beforeEach(() => startGame(game));
+
+  function clearTheField(g: GameState) {
+    for (const inv of g.formation.invaders) inv.alive = false;
+  }
+
+  it('moves to waveClear and pays the bonus', () => {
+    clearTheField(game);
+    step(game, 16, IDLE, NEVER_BOMB);
+    expect(game.phase).toBe('waveClear');
+    expect(game.waveBonus).toBe(160);
+    expect(game.score).toBe(160);
+  });
+
+  it('reproduces the mock: 480 points on wave 3', () => {
+    game.wave = 3;
+    clearTheField(game);
+    step(game, 16, IDLE, NEVER_BOMB);
+    expect(game.waveBonus).toBe(480);
+  });
+
+  it('accepts no input for two seconds', () => {
+    clearTheField(game);
+    step(game, 16, IDLE, NEVER_BOMB);
+    const from = game.playerX;
+    step(game, 100, { ...IDLE, right: true, fire: true }, NEVER_BOMB);
+    expect(game.playerX).toBe(from);
+    expect(game.shot).toBeNull();
+    expect(game.phase).toBe('waveClear');
+  });
+
+  it('starts the next wave lower, with fresh bunkers and no leftovers', () => {
+    clearTheField(game);
+    game.bombs = [{ x: 0, y: 0, rank: 0 }];
+    step(game, 16, IDLE, NEVER_BOMB);
+    const top = game.formation.top;
+
+    step(game, WAVE_CLEAR_MS, IDLE, NEVER_BOMB);
+
+    expect(game.phase).toBe('playing');
+    expect(game.wave).toBe(2);
+    expect(game.formation.top).toBeGreaterThan(top);
+    expect(alive(game.formation)).toHaveLength(45);
+    expect(game.bombs).toHaveLength(0);
+    for (const b of game.bunkers) expect(litCells(b)).toBe(23);
+  });
+});
+
+describe('pause', () => {
+  beforeEach(() => startGame(game));
+
+  it('stops the clock, so the beat does not fire the moment you resume', () => {
+    const beatAt = game.formation.nextBeatAt;
+    togglePause(game);
+    expect(game.phase).toBe('paused');
+
+    step(game, 10_000, IDLE, ALWAYS_BOMB);
+    expect(game.now).toBe(0);
+    expect(game.bombs).toHaveLength(0);
+
+    togglePause(game);
+    expect(game.phase).toBe('playing');
+    expect(game.formation.nextBeatAt).toBe(beatAt);
+  });
+
+  it('is ignored outside play', () => {
+    game.phase = 'gameOver';
+    togglePause(game);
+    expect(game.phase).toBe('gameOver');
+  });
+});
+
+describe('playerRect', () => {
+  it('is a sprite cell wide, four rows tall, at the player row', () => {
+    expect(playerRect(game).w).toBeCloseTo(CELL_W, 5);
+    expect(playerRect(game).y).toBeCloseTo(PLAYER_TOP, 5);
+  });
+});

--- a/tests/unit/invaders-state.test.ts
+++ b/tests/unit/invaders-state.test.ts
@@ -263,6 +263,27 @@ describe('taking a hit', () => {
     expect(game.hitUntil).toBe(0);
     expect(game.respawnUntil).toBe(0);
   });
+
+  it('leaves no invader bursting once the game is over', () => {
+    // A burst is also a deadline in game time, so a kill on the final frame
+    // left an invader painted accent forever once s.now stopped.
+    const target = game.formation.invaders.find((i) => i.rank === RANKS - 1 && i.col === 4)!;
+    const box = invaderRect(game.formation, target);
+    game.shot = { x: box.x + CELL_W / 2, y: box.y + box.h - 1 };
+    bombOnPlayer(game);
+
+    for (let i = 0; i < LIVES - 1; i += 1) {
+      game.respawnUntil = 0;
+      step(game, 16, IDLE, NEVER_BOMB);
+      bombOnPlayer(game);
+    }
+    game.respawnUntil = 0;
+    step(game, 16, IDLE, NEVER_BOMB);
+
+    expect(game.phase).toBe('gameOver');
+    expect(target.burstUntil).toBe(0);
+    expect(game.formation.invaders.every((inv) => inv.burstUntil === 0)).toBe(true);
+  });
 });
 
 describe('deathFor', () => {

--- a/tests/unit/invaders-state.test.ts
+++ b/tests/unit/invaders-state.test.ts
@@ -249,6 +249,20 @@ describe('taking a hit', () => {
     expect(game.phase).toBe('gameOver');
     expect(game.death).toEqual({ rank: 1, row: RANKS });
   });
+
+  it('leaves no live flash or respawn timer once the game is over', () => {
+    // The flash and the respawn are both deadlines in game time, and game time
+    // stops at game over. A deadline left in the future never expires, which once
+    // left the whole field painted accent behind the game over panel.
+    for (let i = 0; i < LIVES; i += 1) {
+      game.respawnUntil = 0;
+      bombOnPlayer(game);
+      step(game, 16, IDLE, NEVER_BOMB);
+    }
+    expect(game.phase).toBe('gameOver');
+    expect(game.hitUntil).toBe(0);
+    expect(game.respawnUntil).toBe(0);
+  });
 });
 
 describe('deathFor', () => {
@@ -287,6 +301,8 @@ describe('the ground line', () => {
     step(game, game.formation.nextBeatAt + 1, IDLE, NEVER_BOMB);
     expect(game.phase).toBe('gameOver');
     expect(game.death).not.toBeNull();
+    expect(game.hitUntil).toBe(0);
+    expect(game.respawnUntil).toBe(0);
   });
 });
 

--- a/tests/unit/invaders-transition.test.ts
+++ b/tests/unit/invaders-transition.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { blockAt, veilAt } from '../../src/lib/invaders/transition';
+
+describe('blockAt', () => {
+  it('hits every keyframe the handoff names', () => {
+    expect(blockAt(0)).toBeCloseTo(1, 5);
+    expect(blockAt(160)).toBeCloseTo(6, 5);
+    expect(blockAt(380)).toBeCloseTo(20, 5);
+    expect(blockAt(520)).toBeCloseTo(40, 5);
+    expect(blockAt(650)).toBeCloseTo(8, 5);
+    expect(blockAt(720)).toBeCloseTo(1, 5);
+  });
+
+  it('falls in resolution up to 520ms', () => {
+    let previous = blockAt(0);
+    for (let t = 20; t <= 520; t += 20) {
+      const now = blockAt(t);
+      expect(now).toBeGreaterThan(previous);
+      previous = now;
+    }
+  });
+
+  // The reversal is the idea. A fade would leave this monotonic all the way to
+  // 720ms, and the invaders would never appear to come out of the page's pixels.
+  it('climbs back from 520ms rather than fading', () => {
+    let previous = blockAt(520);
+    for (let t = 540; t <= 720; t += 20) {
+      const now = blockAt(t);
+      expect(now).toBeLessThan(previous);
+      previous = now;
+    }
+  });
+
+  it('never goes under one pixel', () => {
+    for (let t = 0; t <= 800; t += 10) expect(blockAt(t)).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('veilAt', () => {
+  it('is off until 380ms', () => {
+    expect(veilAt(0)).toBe(0);
+    expect(veilAt(379)).toBe(0);
+  });
+
+  it('builds to 70 percent by 520ms', () => {
+    expect(veilAt(450)).toBeGreaterThan(0);
+    expect(veilAt(450)).toBeLessThan(0.7);
+    expect(veilAt(520)).toBeCloseTo(0.7, 5);
+  });
+
+  // The handoff builds the veil and never takes it off. It has to come off, or
+  // the invaders resolve under a 70 percent wash of the field colour and are
+  // never seen.
+  it('retreats to nothing by 650ms, so the invaders can resolve', () => {
+    expect(veilAt(585)).toBeCloseTo(0.35, 5);
+    expect(veilAt(650)).toBe(0);
+    expect(veilAt(720)).toBe(0);
+  });
+});


### PR DESCRIPTION
A hidden Space Invaders game, reachable from the accent square in the window chrome. Desktop only:
above 900px and under `(pointer: fine)`. Below either, the square is the inert dot it has always been.

Built from the design handoff in `~/Downloads/handoff-invaders`. The implementation spec is at
`docs/superpowers/specs/2026-08-18-invaders-design.md` and records every place this departs from it.

## Finding it

The third chrome dot already looked like a button, because in a real terminal it is one. Now it is.
Hover it and the chrome bar's right-hand meta text is replaced by `./invaders` in the accent with a
blinking caret. That swap is the whole affordance: no tooltip, no title attribute, no cursor change on
the bar. Tab reaches it, Enter opens it. Typing `i n v` anywhere works too, and is undocumented on
purpose.

## The transition

Clicking rasterises the page to a canvas and redraws it at falling resolution: 1px blocks to 6 by
160ms, 20 by 380ms, 40 by 520ms, desaturating toward the play field's near-black as it goes. At 520ms
the resolution climbs back, but the source has changed to the game's opening formation, so the cells
turn out to be invaders. That reversal is the idea, and it is not a fade.

Escape runs the same curve backwards over 480ms with the page as the destination, and restores the
scroll position exactly. The URL never changes: no route, no history entry, no shareable game link.

The game DOM mounts before the transition runs, underneath the canvas. That is not incidental. It is
how the transition learns where the field will be, so the formation it draws at 520ms lands where the
real one appears at 720ms.

Under `prefers-reduced-motion: reduce` there is no canvas and no pixelation: a 120ms crossfade both
ways. The game itself still runs, because it is content rather than decoration.

## How it is built

```mermaid
graph TD
  idx["index.ts<br/>entry, on every page"] -.->|dynamic| game["game.ts<br/>lifecycle and rAF loop"]
  idx -.->|dynamic| trans["transition.ts<br/>the pixelation"]
  trans -.->|dynamic| h2c["html2canvas"]
  game --> view["view.ts<br/>state to DOM"]
  game --> state["state.ts<br/>the machine"]
  state --> form["formation.ts"]
  state --> proj["projectiles.ts"]
  state --> bunk["bunkers.ts"]
  state --> coll["collide.ts"]
  form --> rules["rules.ts<br/>geometry and timings"]
  view --> sprites["sprites.ts<br/>the art as data"]
  sprites --> rules
```

Everything from `state.ts` down is pure: no DOM, no clock, no randomness. Game time and the random
source arrive as arguments, which is what lets 211 unit tests drive every rule without a browser.
`view.ts` reads state and writes DOM and holds no rule of its own. The loop reads input, steps the
machine, and hands the result to the view; it decides nothing.

The window is an Astro `<template>` in `BaseLayout` rather than a hidden subtree. Template content
lives in its own `DocumentFragment`, so it stays out of the accessibility tree and out of
`document.querySelectorAll` until it is cloned, which keeps the site's existing caret and glyph sweeps
from seeing a window that is not on screen.

Sprites are Departure Mono block glyphs, one `<div>` per row inside a `<pre>`, the same rule
`CodeBlock` obeys and for the same reason. Both frames of every invader sit in the DOM and the field
carries a `data-frame` attribute saying which shows, so a beat costs one attribute write rather than
225 text writes at a tempo that can fall to 90ms.

A reader who never finds the game downloads a 3137 byte entry script and nothing else. `html2canvas`
is the only new dependency and it loads on hovering the trigger, not on page load. There is a test
asserting the eager chunk carries no sprite art, because that guarantee lived in a comment once and
quietly stopped being true.

## Where this departs from the handoff

Five places, each with a reason:

- **Bunkers erode by a 3x3 block, not the cell plus four neighbours.** The five-cell mask cannot
  finish a bunker: it leaves a six-cell checkerboard no aim clears, which contradicts the handoff's own
  "four states, then gone". A 3x3 block reaches gone in five spread hits.
- **Bunkers use `--color-ink-faint`, not the literal `#767386`.** That hex is the pre-lift value of
  the same token, from commit 08e9e6c which raised it to clear 4.5:1.
- **One extra token.** The title screen sets `tracking .3em` and the scale had no such step, so
  `--tracking-title` joins `--game-beat` and `--game-field`.
- **The desaturation veil retreats after 520ms.** The handoff only builds it. It has to come off, or
  the invaders resolve under a 70% wash and are never seen.
- **A wave starts one rank lower, once.** The field is 466px and the formation 294px, leaving 74.56px
  above the player against a 61.8px rank pitch, so only one wave of drop physically fits. Later waves
  take their difficulty from the beat floor.

## Changes outside the game

`Window.astro`'s chrome dots lose their shared `aria-hidden` wrapper, because a focusable button inside
one is an axe violation; each inert span carries its own instead. The accent dot renders as a button or
an inert span, never both, so the visible dot count is unchanged at every width and `layout.spec.ts`
needed no edit.

`CommandPalette.tsx` will no longer open on top of another modal. Without that guard, ⌘K raised the
palette behind the game and moved focus into its search field, and since the palette navigates on
Enter, a player typing a few letters and pressing Enter was taken off the page.

`motion.spec.ts` now selects a visible caret rather than the first in the document. Its comment claimed
the home page has only one caret, and the chrome bar's hidden `./invaders` hint caret made that false.

## Tested

211 unit tests over the rules: the beat and its floor, the wall and the descent, one shot in flight,
three bombs at most, bunker erosion, scoring, waves, lives, and the five phase changes. 357 browser
tests including the trigger's gating on width and pointer type, the exit restoring scroll from every
reachable state, axe over the open game, keyboard-only play from the trigger to a fired shot, a glyph
audit run with the game on screen, and a check that nothing on the field except the cannon carries the
accent.

## Not covered

Wave clear was never reached in live play, so its rendering is verified by unit tests and source
reading rather than by eye. Game over needs about fifty seconds of real play to reach, so it has no
browser test either; the state rule behind it does. The four-viewport sweep against the handoff screens
is manual, per `docs/verification.md`.

Sound is out of scope by the handoff's own instruction. Nothing here plays any, and no hooks were left
for it.
