### PR TITLE
fix: resolve the invaders transition onto the real game screen

### DIFF
--- a/src/lib/invaders/game.ts
+++ b/src/lib/invaders/game.ts
@@ -1,5 +1,13 @@
 import { HI_SCORE_KEY, clampPlayerX } from './rules';
-import { createGame, startGame, step, togglePause, type GameState, type Input } from './state';
+import {
+  createGame,
+  startGame,
+  step,
+  togglePause,
+  type GameState,
+  type Input,
+  type Phase,
+} from './state';
 import { build, collect, render, type Refs } from './view';
 
 /**
@@ -17,6 +25,7 @@ let trigger: HTMLElement | null = null;
 let frame = 0;
 let lastFrameAt = 0;
 let builtWave = 0;
+let shownPhase: Phase | null = null;
 let savedHi = 0;
 let restoreScroll = 0;
 
@@ -52,6 +61,25 @@ function mount(): HTMLElement {
   return el;
 }
 
+/**
+ * Keeps the exit transition's copy of the window true to the screen.
+ *
+ * The exit resolves onto a raster of this window and needs it the instant Escape
+ * lands, so it cannot be taken on demand. `playing` never holds still, so there
+ * the copy is dropped and the exit runs on the formation instead.
+ */
+async function refreshExitCopy(phase: Phase): Promise<void> {
+  if (!root) return;
+  try {
+    const { invalidateGame, prepareGame } = await import('./transition');
+    invalidateGame();
+    if (phase !== 'playing') prepareGame();
+  } catch {
+    // The copy is an optimisation for one transition. A chunk that will not load
+    // is not worth breaking a running game over.
+  }
+}
+
 function tick(now: number): void {
   frame = requestAnimationFrame(tick);
   if (!state || !refs) return;
@@ -72,6 +100,11 @@ function tick(now: number): void {
   }
 
   render(refs, state);
+
+  if (state.phase !== shownPhase) {
+    shownPhase = state.phase;
+    void refreshExitCopy(state.phase);
+  }
 
   if (state.hi > savedHi) {
     savedHi = state.hi;
@@ -156,6 +189,9 @@ export async function openGame(): Promise<void> {
   savedHi = readHiScore();
   state = createGame(savedHi, refs.field.clientWidth);
   builtWave = state.wave;
+  // Seeded, not left null: the enter transition takes the raster itself, and a
+  // first tick that read this as a phase change would throw that copy away.
+  shownPhase = state.phase;
   build(refs, state);
   render(refs, state);
 
@@ -197,8 +233,11 @@ export async function closeGame(): Promise<void> {
   if (state && state.hi > savedHi) writeHiScore(state.hi);
 
   try {
-    const { run } = await import('./transition');
+    const { invalidateGame, run } = await import('./transition');
     await run(refs.field.getBoundingClientRect(), 'out');
+    // The copy outlives this window otherwise, and the next open would resolve
+    // onto the last session's screen: an old hi score, an old phase.
+    invalidateGame();
   } catch (error) {
     // Same reasoning as openGame, and it matters more here: the keydown listener
     // is already gone, so a throw would leave the page locked with the modal up
@@ -210,6 +249,7 @@ export async function closeGame(): Promise<void> {
   root = null;
   refs = null;
   state = null;
+  shownPhase = null;
 
   document.body.style.overflow = '';
   window.scrollTo(0, restoreScroll);

--- a/src/lib/invaders/transition.ts
+++ b/src/lib/invaders/transition.ts
@@ -15,24 +15,48 @@ import { RANK_INK, RANK_SPRITE, SPRITE_COLS, gridCells } from './sprites';
  *
  * One canvas covers the frozen viewport. Each frame draws the source into a
  * small offscreen canvas and blows it back up with smoothing off, so the block
- * size is the only thing being animated. At 520ms the source changes from the
- * rasterised page to the game's opening formation, and the climb back in
- * resolution is then the same operation on a different picture. That reversal is
- * the whole idea: it is why the invaders look like they were in the page all
- * along, and it is not a fade.
+ * size is the only thing being animated. The climb back in resolution is the
+ * same operation on a different picture. That reversal is the whole idea: it is
+ * why the invaders look like they were in the page all along, and it is not a
+ * fade.
+ *
+ * There are three sources, in this order. The rasterised page carries 0 to
+ * 520ms. The hand-drawn formation carries the turn at 520ms, which is where the
+ * invaders come out of the page's own pixels. From 520ms to 650ms it crosses to
+ * a raster of the mounted game window, so the resolution the curve climbs back
+ * to is the screen the reader actually gets. That third source is the whole
+ * reason the hand-over is invisible: the formation alone is a picture the game
+ * never draws, because on the title screen the panel covers the field.
  */
 
 const IN_MS = 720;
 const OUT_MS = 480;
 
-/** Time in milliseconds against block size in pixels, straight from the handoff. */
+/**
+ * Time in milliseconds against block size in pixels.
+ *
+ * The handoff's table, with one change: it ends 650ms at 8px and 720ms at 1px,
+ * and both are 24px here. Two separate measurements force it.
+ *
+ * A sprite cell is 8.27 by 9.36px, so a block of 8 redraws the invaders almost
+ * exactly rather than coarsely.
+ *
+ * The game raster cannot be registered against the DOM any finer than about 20px.
+ * html2canvas lays text out on its own line boxes and the error accumulates down
+ * the page: 0px on the window frame, 6px on the HUD, 10px in the field, 7px on the
+ * footer. Under half a block that error is invisible; over it, every line doubles.
+ *
+ * So the hand-over from 650ms to 720ms holds its block and cross-fades instead of
+ * resolving. The sharp picture the reader ends on is the real DOM under the canvas,
+ * which is what shows through as the canvas fades off it.
+ */
 const KEYFRAMES: readonly [number, number][] = [
   [0, 1],
   [160, 6],
   [380, 20],
   [520, 40],
-  [650, 8],
-  [720, 1],
+  [650, 24],
+  [720, 24],
 ];
 
 /** Where the source stops being the page and starts being the game. */
@@ -42,10 +66,23 @@ const VEIL_UNTIL_MS = 650;
 const VEIL_PEAK = 0.7;
 const ARRIVE_MS = 650;
 
+/**
+ * When the game raster starts, measured from the opening of the transition.
+ *
+ * The raster is mostly asynchronous but it holds the main thread for one stretch
+ * of about 60ms, and that stretch lands roughly 80ms after the call. Starting
+ * here puts it between 340ms and 410ms, the slowest part of the block curve,
+ * where a few dropped frames do not read as a stutter. It also leaves the raster
+ * finished well before 520ms, where it is first needed.
+ */
+const RASTER_GAME_AT_MS = 260;
+
 const FIELD_COLOUR = '#0b0b10';
 
 let pageCanvas: HTMLCanvasElement | null = null;
 let pending: Promise<HTMLCanvasElement> | null = null;
+let gameCanvas: HTMLCanvasElement | null = null;
+let gamePending: Promise<HTMLCanvasElement> | null = null;
 let listening = false;
 
 function reduced(): boolean {
@@ -87,6 +124,91 @@ function rasterise(): Promise<HTMLCanvasElement> {
 export function invalidate(): void {
   pageCanvas = null;
   pending = null;
+  invalidateGame();
+}
+
+/** The field's sprite layers, in the order the shell stacks them. */
+const SPRITE_LAYERS = [
+  '[data-invaders-formation]',
+  '[data-invaders-bunkers]',
+  '[data-invaders-bombs]',
+  '[data-invaders-shot]',
+  '[data-invaders-player]',
+];
+
+/** True while a panel covers the field, so nothing under it can show. */
+function fieldCovered(): boolean {
+  return ['title', 'waveClear', 'gameOver'].some(
+    (name) =>
+      document.querySelector<HTMLElement>(`[data-invaders-panel="${name}"]`)?.hidden === false
+  );
+}
+
+/**
+ * Rasterises the game window, cached.
+ *
+ * The target is the game root, not `document.body`. Rasterising the body costs
+ * three times as much for the same picture, and it would also have to exclude our
+ * own canvas, which is a sibling of the root. Rasterising the root excludes it for
+ * free.
+ *
+ * `ignoreElements` drops the field's sprite layers whenever a panel covers the
+ * field. That is 45 invaders of three `pre` each, so the clone is most of the cost:
+ * dropping them takes the call from about 290ms to 120ms and its one long main
+ * thread task from 190ms to 33ms. Under `paused` the field shows through, so the
+ * layers stay and the call pays full price, which is free of consequence because
+ * nothing is animating on a paused game.
+ *
+ * `onclone` edits the clone, never the page. It strips `data-arriving`, because the
+ * HUD and the footer are still parked off the frame edges while this runs and the
+ * raster has to show them where they finally sit.
+ */
+function rasteriseGame(root: HTMLElement): Promise<HTMLCanvasElement> {
+  if (gameCanvas) return Promise.resolve(gameCanvas);
+  const covered = fieldCovered();
+  gamePending ??= import('html2canvas')
+    .then(({ default: html2canvas }) =>
+      html2canvas(root, {
+        scale: 1,
+        logging: false,
+        backgroundColor: getComputedStyle(document.body).backgroundColor,
+        width: window.innerWidth,
+        height: window.innerHeight,
+        ignoreElements: covered
+          ? (element) => SPRITE_LAYERS.some((selector) => element.matches(selector))
+          : undefined,
+        onclone: (_document, element) => element.removeAttribute('data-arriving'),
+      })
+    )
+    .then((canvas) => {
+      gameCanvas = canvas;
+      return canvas;
+    })
+    .catch((error) => {
+      gamePending = null;
+      throw error;
+    });
+  return gamePending;
+}
+
+/** Drops the game raster, because the screen it copied has changed. */
+export function invalidateGame(): void {
+  gameCanvas = null;
+  gamePending = null;
+}
+
+/**
+ * Takes the game raster now, for a screen that has stopped moving.
+ *
+ * The exit needs it the instant Escape lands, and it costs about 150ms, so it
+ * cannot be taken on demand. Every phase but `playing` holds still, so the game
+ * calls this on reaching one and the copy stays true until the phase changes.
+ */
+export function prepareGame(): void {
+  if (reduced()) return;
+  const root = document.querySelector<HTMLElement>('[data-invaders-root]');
+  if (!root) return;
+  void rasteriseGame(root).catch(() => undefined);
 }
 
 /** Warms the raster before the click, so the click itself feels instant. */
@@ -100,16 +222,29 @@ export function prepare(): void {
   void rasterise().catch(() => undefined);
 }
 
-/** The game's opening formation, drawn where the real field is about to be. */
-function formationCanvas(field: DOMRect, w: number, h: number): HTMLCanvasElement {
+/**
+ * The game's opening formation, drawn where the real field is about to be.
+ *
+ * It sits on the page raster rather than on a full bleed fill of the field
+ * colour. The game keeps the page's window frame, border and chrome bar, so
+ * blacking the whole viewport made 520ms read as the window vanishing. On the
+ * page raster, 520ms changes the field and nothing else.
+ */
+function formationCanvas(
+  page: HTMLCanvasElement,
+  field: DOMRect,
+  w: number,
+  h: number
+): HTMLCanvasElement {
   const canvas = document.createElement('canvas');
   canvas.width = Math.max(1, Math.round(w));
   canvas.height = Math.max(1, Math.round(h));
   const ctx = canvas.getContext('2d');
   if (!ctx) return canvas;
 
+  ctx.drawImage(page, 0, 0, canvas.width, canvas.height);
   ctx.fillStyle = FIELD_COLOUR;
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillRect(field.left, field.top, field.width, field.height);
 
   const styles = getComputedStyle(document.documentElement);
   const cellW = CELL_W / SPRITE_COLS;
@@ -168,6 +303,36 @@ export function veilAt(t: number): number {
 }
 
 /**
+ * How far the source has crossed from the formation to the real game screen.
+ *
+ * The formation is hand drawn, so it can only ever approximate what the reader
+ * gets. On the title screen the panel covers the field, so the real screen has no
+ * invaders on it at all. Crossing to a raster of the mounted window before the
+ * blocks get fine enough to read is what keeps the hand-over off a picture the
+ * game never draws. The cross-fade runs under the retreating veil, so the change
+ * of source is never a cut.
+ */
+export function arriveAt(t: number): number {
+  if (t <= SWITCH_MS) return 0;
+  if (t >= ARRIVE_MS) return 1;
+  return (t - SWITCH_MS) / (ARRIVE_MS - SWITCH_MS);
+}
+
+/**
+ * The canvas's own opacity at `t`.
+ *
+ * The handoff hands the frame over between 650ms and 720ms rather than cutting:
+ * the game DOM is already mounted underneath, and the HUD and footer slide in
+ * from the frame edges over that same 70ms. A cut would end on one fully opaque
+ * frame of a formation the game never draws, because the title panel covers the
+ * field. Both directions read this, which is what gives the exit its fade in.
+ */
+export function fadeAt(t: number): number {
+  if (t <= ARRIVE_MS) return 1;
+  return Math.max(0, 1 - (t - ARRIVE_MS) / (IN_MS - ARRIVE_MS));
+}
+
+/**
  * Runs the pixelation. `in` dissolves the page into the game, `out` reverses it
  * over 480ms with the page as the destination.
  *
@@ -199,12 +364,22 @@ export async function run(field: DOMRect, direction: 'in' | 'out'): Promise<void
   if (!raster) return;
   const page = raster;
 
-  const game = formationCanvas(field, w, h);
+  const formation = formationCanvas(page, field, w, h);
+  const total = direction === 'in' ? IN_MS : OUT_MS;
+  // The exit is the same curve, played backwards and compressed.
+  const timeAt = (elapsed: number): number =>
+    direction === 'in' ? elapsed : IN_MS * (1 - elapsed / total);
+
   const canvas = document.createElement('canvas');
   canvas.dataset.invadersCanvas = '';
   canvas.width = w;
   canvas.height = h;
-  canvas.style.cssText = `position:fixed;inset:0;width:100%;height:100%;z-index:60;pointer-events:none`;
+  // The starting opacity is written here as well as per frame. The exit opens
+  // part way through the hand-over, so the canvas must never reach the
+  // compositor opaque before the first frame has drawn into it.
+  canvas.style.cssText =
+    `position:fixed;inset:0;width:100%;height:100%;z-index:60;pointer-events:none;` +
+    `opacity:${fadeAt(timeAt(0))}`;
   document.body.append(canvas);
 
   const rawCtx = canvas.getContext('2d');
@@ -222,24 +397,48 @@ export async function run(field: DOMRect, direction: 'in' | 'out'): Promise<void
 
   root?.setAttribute('data-arriving', '');
 
-  const total = direction === 'in' ? IN_MS : OUT_MS;
   const start = performance.now();
+  let rastering = false;
+  // `undefined` until the cross-fade opens and the decision is taken, then either
+  // the raster to cross to or `null` for "run on the formation alone".
+  let arrived: HTMLCanvasElement | null | undefined;
 
   await new Promise<void>((resolve) => {
     function frame(now: number): void {
       const elapsed = Math.min(total, now - start);
-      // The exit is the same curve, played backwards and compressed.
-      const t = direction === 'in' ? elapsed : IN_MS * (1 - elapsed / total);
+      const t = timeAt(elapsed);
+
+      // Started here rather than at mount. The raster holds the main thread for
+      // one stretch of about 60ms, and this is the slowest part of the curve.
+      if (direction === 'in' && !rastering && elapsed >= RASTER_GAME_AT_MS) {
+        rastering = true;
+        prepareGame();
+      }
+
+      // Locked in when the cross-fade opens, so a raster that lands halfway
+      // through cannot pop into the picture mid hand-over. The exit reads it on
+      // its first frame, from the copy taken while the screen was still.
+      if (arrived === undefined && t >= SWITCH_MS) arrived = gameCanvas;
 
       const block = Math.max(1, blockAt(t));
-      // Both directions read the same curve, so `t` already carries the direction.
-      const source = t < SWITCH_MS ? page : game;
 
       const sw = Math.max(1, Math.round(w / block));
       const sh = Math.max(1, Math.round(h / block));
       small.width = sw;
       small.height = sh;
-      smallCtx.drawImage(source, 0, 0, sw, sh);
+
+      // Both directions read the same curve, so `t` already carries the direction.
+      if (t < SWITCH_MS) {
+        smallCtx.drawImage(page, 0, 0, sw, sh);
+      } else {
+        smallCtx.drawImage(formation, 0, 0, sw, sh);
+        const across = arrived ? arriveAt(t) : 0;
+        if (across > 0 && arrived) {
+          smallCtx.globalAlpha = across;
+          smallCtx.drawImage(arrived, 0, 0, sw, sh);
+          smallCtx.globalAlpha = 1;
+        }
+      }
 
       ctx.imageSmoothingEnabled = false;
       ctx.clearRect(0, 0, w, h);
@@ -253,13 +452,14 @@ export async function run(field: DOMRect, direction: 'in' | 'out'): Promise<void
         ctx.globalAlpha = 1;
       }
 
-      // The canvas comes down here too, not just at the end: the HUD and
-      // footer slide into view over the 70ms after this, on the real DOM, and
-      // that motion would be invisible under a canvas that outlives it.
-      if (direction === 'in' && elapsed >= ARRIVE_MS) {
-        root?.removeAttribute('data-arriving');
-        canvas.remove();
-      }
+      // The canvas fades off the real DOM rather than being cut away from it.
+      // `t` carries the direction, so the exit reads the same ramp backwards and
+      // fades in over its first 70ms instead of opening on a sharp formation.
+      canvas.style.opacity = String(fadeAt(t));
+
+      // The HUD and footer slide into view over the same 70ms, under the fading
+      // canvas. The exit keeps the attribute until the end, so they slide out.
+      if (direction === 'in' && t >= ARRIVE_MS) root?.removeAttribute('data-arriving');
 
       if (elapsed >= total) {
         resolve();

--- a/tests/e2e/invaders.spec.ts
+++ b/tests/e2e/invaders.spec.ts
@@ -496,8 +496,8 @@ test.describe('the transition', () => {
     await page.locator('[data-invaders-open]').click();
     await expect(page.locator('[data-invaders-canvas]')).toBeVisible();
     await expect(page.locator('[data-invaders-canvas]')).toHaveCount(0, { timeout: 4000 });
-    // The canvas comes down at 650ms, ahead of the 720ms mark where input
-    // arms; without this wait Escape can land in that gap and do nothing.
+    // The canvas fades out from 650ms and comes down at 720ms, the same mark
+    // where input arms; without this wait Escape can race it and do nothing.
     await expect(page.locator('[data-invaders-root]')).toHaveAttribute('data-armed', '');
     await page.keyboard.press('Escape');
     await expect(page.locator('[data-invaders-root]')).toHaveCount(0);

--- a/tests/unit/invaders-transition.test.ts
+++ b/tests/unit/invaders-transition.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { blockAt, veilAt } from '../../src/lib/invaders/transition';
+import { CELL_H, CELL_W, RANKS, SPRITE_COLS } from '../../src/lib/invaders/rules';
+import { arriveAt, blockAt, fadeAt, veilAt } from '../../src/lib/invaders/transition';
 
 describe('blockAt', () => {
   it('hits every keyframe the handoff names', () => {
@@ -7,8 +8,8 @@ describe('blockAt', () => {
     expect(blockAt(160)).toBeCloseTo(6, 5);
     expect(blockAt(380)).toBeCloseTo(20, 5);
     expect(blockAt(520)).toBeCloseTo(40, 5);
-    expect(blockAt(650)).toBeCloseTo(8, 5);
-    expect(blockAt(720)).toBeCloseTo(1, 5);
+    expect(blockAt(650)).toBeCloseTo(24, 5);
+    expect(blockAt(720)).toBeCloseTo(24, 5);
   });
 
   it('falls in resolution up to 520ms', () => {
@@ -21,18 +22,34 @@ describe('blockAt', () => {
   });
 
   // The reversal is the idea. A fade would leave this monotonic all the way to
-  // 720ms, and the invaders would never appear to come out of the page's pixels.
+  // 650ms, and the invaders would never appear to come out of the page's pixels.
   it('climbs back from 520ms rather than fading', () => {
     let previous = blockAt(520);
-    for (let t = 540; t <= 720; t += 20) {
+    for (let t = 540; t <= 650; t += 10) {
       const now = blockAt(t);
       expect(now).toBeLessThan(previous);
       previous = now;
     }
   });
 
+  // The game raster carries the hand-over and it cannot be registered against the
+  // DOM below about 20px, so the last 70ms cross-fades at a held block instead of
+  // resolving. Resolving it would double every line in the window.
+  it('holds its block across the hand-over rather than resolving', () => {
+    for (let t = 650; t <= 720; t += 10) expect(blockAt(t)).toBeCloseTo(24, 5);
+  });
+
   it('never goes under one pixel', () => {
     for (let t = 0; t <= 800; t += 10) expect(blockAt(t)).toBeGreaterThanOrEqual(1);
+  });
+
+  // A block the size of a sprite cell redraws the invaders almost exactly, and
+  // the hand-over frame is the last one at full opacity. At block 8 that frame
+  // read as a formation on a bare field, which is a screen the game never shows:
+  // the title panel covers the field. Keep the hand-over well clear of the cell.
+  it('hands over at a block far coarser than a sprite cell', () => {
+    const cell = Math.max(CELL_W / SPRITE_COLS, CELL_H / RANKS);
+    expect(blockAt(650)).toBeGreaterThan(cell * 1.5);
   });
 });
 
@@ -55,5 +72,73 @@ describe('veilAt', () => {
     expect(veilAt(585)).toBeCloseTo(0.35, 5);
     expect(veilAt(650)).toBe(0);
     expect(veilAt(720)).toBe(0);
+  });
+});
+
+describe('fadeAt', () => {
+  it('holds the canvas opaque up to the hand-over', () => {
+    expect(fadeAt(0)).toBe(1);
+    expect(fadeAt(520)).toBe(1);
+    expect(fadeAt(650)).toBe(1);
+  });
+
+  // The handoff hands the frame over between 650ms and 720ms. A cut instead of a
+  // ramp shows one fully opaque frame at block 8, and block 8 is one sprite cell
+  // wide, so that frame is a legible formation the game itself never draws.
+  it('ramps to nothing across the 70ms hand-over', () => {
+    expect(fadeAt(685)).toBeCloseTo(0.5, 5);
+    expect(fadeAt(720)).toBe(0);
+  });
+
+  // The exit reads the same curve backwards, so a monotonic ramp here is what
+  // gives the exit its fade in. Without it the exit opens on a sharp formation.
+  it('falls the whole way, which is what fades the exit in', () => {
+    let previous = fadeAt(650);
+    for (let t = 660; t <= 720; t += 10) {
+      const now = fadeAt(t);
+      expect(now).toBeLessThan(previous);
+      previous = now;
+    }
+  });
+
+  it('never leaves the 0 to 1 range', () => {
+    for (let t = 0; t <= 800; t += 10) {
+      expect(fadeAt(t)).toBeGreaterThanOrEqual(0);
+      expect(fadeAt(t)).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('arriveAt', () => {
+  it('is pure formation until the block curve turns at 520ms', () => {
+    expect(arriveAt(0)).toBe(0);
+    expect(arriveAt(380)).toBe(0);
+    expect(arriveAt(520)).toBe(0);
+  });
+
+  // The formation is hand drawn, so it can only approximate the screen the reader
+  // gets. On the title screen the panel covers the field, so the real screen has
+  // no invaders on it at all. Crossing to the raster before the blocks get fine
+  // enough to read is what keeps the hand-over off a screen the game never shows.
+  it('is the real game screen by the hand-over', () => {
+    expect(arriveAt(650)).toBe(1);
+    expect(arriveAt(720)).toBe(1);
+  });
+
+  it('crosses over under the retreating veil, so the swap is never a cut', () => {
+    expect(arriveAt(585)).toBeCloseTo(0.5, 5);
+    let previous = arriveAt(520);
+    for (let t = 530; t <= 650; t += 10) {
+      const now = arriveAt(t);
+      expect(now).toBeGreaterThan(previous);
+      previous = now;
+    }
+  });
+
+  it('never leaves the 0 to 1 range', () => {
+    for (let t = 0; t <= 800; t += 10) {
+      expect(arriveAt(t)).toBeGreaterThanOrEqual(0);
+      expect(arriveAt(t)).toBeLessThanOrEqual(1);
+    }
   });
 });


### PR DESCRIPTION
## The bug

Entering and leaving the game flashed the whole invader formation for a moment, then
switched to the title screen. Same on the way out.

I sliced a screencast frame by frame to find it. The transition's canvas came up at
2.658s and disappeared at 3.308s, exactly the 650ms `ARRIVE_MS` mark. The last frame
it painted was `formationCanvas()` at close to full sharpness: the whole viewport
filled with the field colour plus all 45 invaders in a 9 by 5 grid, and nothing else.
No window frame, no chrome bar, no HUD, no footer.

The game underneath was showing something else entirely. It opens in the `title`
phase, and `[data-invaders-panel="title"]` is opaque `rgb(11, 11, 16)` covering the
field exactly. `elementFromPoint` over invader one returns the title panel. The game
never shows a single invader on that screen. `tests/e2e/invaders.spec.ts` even has a
test named "a panel covers the field rather than sitting over the invaders".

Three things compounded:

1. **The hand-over was a hard cut.** `docs/superpowers/specs/2026-08-18-invaders-design.md`
   says "From 650ms to 720ms the real game DOM is already mounted under the canvas.
   The canvas fades out." The code called `canvas.remove()` the instant `elapsed >= 650`.
   Opaque on one frame, gone on the next.
2. **Block 8 is one sprite cell.** `blockAt(650)` returned exactly `8`, and a sprite cell
   is `CELL_W / SPRITE_COLS` by `CELL_H / RANKS`, 8.27 by 9.36px. The pixelation grid landed
   on the sprite grid roughly 1:1, so the "still pixelated" frame was pixel-perfect invaders.
   `veilAt(650)` is `0`, so nothing was left to muddy it either.
3. **The destination picture was wrong.** Even sub-pixel-perfect, the picture was a screen
   the game does not draw.

The exit was the same bug, one frame worse. `t = IN_MS * (1 - elapsed / total)` means its
first frame is `t = 720`, so `blockAt(720) = 1` with the formation as the source: a fully
sharp formation dropped on the title screen with no fade in at all.

## The fix

### 1. The canvas fades off the DOM

New `fadeAt(t)` beside `blockAt` and `veilAt`. Opacity 1 to 650ms, then a linear ramp to 0
at 720ms, written per frame. `canvas.remove()` at 650ms is gone. Both directions read the
same `t`, so the exit gets the mirrored fade in for free. Measured on the build:

| | enter | exit |
|---|---|---|
| before | opacity 1, then gone in one frame | opens at opacity 1 on a sharp formation |
| after | 1, .88, .77, .65, .53, .41, .29, .17, 0 | 0, .16, .34, .51, .69, .86, 1 |

### 2. A raster of the game window is the third source

The formation is hand drawn, so it can only ever approximate the screen. Now it carries the
turn at 520ms, where the invaders come out of the page's own pixels, and cross-fades to a
raster of the mounted window by 650ms. `arriveAt(t)` drives that, and it runs under the
retreating veil so the change of source is never a cut.

`formationCanvas` also sits on the page raster now instead of a full bleed fill of the field
colour. The game keeps the page's window frame, border and chrome bar, so blacking the whole
viewport made 520ms read as the window vanishing.

### 3. The hand-over holds its block at 24

This is the part worth reviewing. **html2canvas cannot register against the DOM.** It lays
text out on its own line boxes and the error accumulates down the page. Measured against a
screenshot, band by band:

| band | offset |
|---|---|
| window frame and chrome bar | 0px |
| HUD row | 6px |
| field | 10px |
| footer | 7px |

Resolve that copy to 1px on top of the real DOM and every line doubles. I had it working and
ghosting a second "INVADERS" before I measured this.

So the block table ends `650ms 24px, 720ms 24px`. The hand-over cross-fades at a held block
rather than resolving. Nothing is lost by not reaching 1px: the sharp picture the reader ends
on is the real DOM under the canvas, showing through as the canvas fades off it. Two separate
measurements pin 24: half of the 20px registration error, and comfortably clear of the 8.27px
sprite cell.

### 4. The exit's copy

The exit needs the raster the instant Escape lands and it costs too much to take on demand, so
the game re-takes it on reaching any phase that holds still. `game.ts` tracks `shownPhase` and
calls `invalidateGame()` on every change, then `prepareGame()` when the new phase is not
`playing`. `closeGame` invalidates too, so the next open cannot resolve onto the last session's
hi score.

## What it costs

**The enter drops one frame.** Worst inter-frame gap during the transition, three runs each:

- before: 16.6ms, 9.4ms, 9.4ms. Zero frames over 30ms.
- after: 41.7ms, 33.4ms, 32.5ms. One frame over 30ms, always between t 410 and 427ms.

That is the raster's one long main thread task, deliberately placed. It starts 260ms in so the
task lands near 415ms, where the block curve is slowest. Getting it that small took two steps:

| | call | longest main thread task |
|---|---|---|
| `document.body`, everything | 340 to 420ms | 240 to 310ms |
| the game root, everything | 280 to 310ms | 175 to 200ms |
| the game root, sprite layers dropped | 120ms | 33ms |

`ignoreElements` drops the field's sprite layers whenever a panel covers the field, which is 45
invaders of three `pre` each. Under `paused` the field shows through, so they stay and the call
pays full price, which costs nothing because nothing is animating on a paused game.

**An exit during live play runs on the formation alone.** `playing` never holds still, so no copy
can be true, and taking one on Escape would be 120ms of input lag. The held block and the fade
cover it, and during play the real field does show invaders, so the fallback is showing roughly
the right thing. This is the one path the raster does not reach.

## Verification

- 221 unit tests, 357 e2e, `astro check` clean.
- New unit tests cover `fadeAt` and `arriveAt`, that the hand-over holds its block, and that the
  hand-over block stays clear of a sprite cell. That last one reads `CELL_W`, `SPRITE_COLS`,
  `CELL_H` and `RANKS` from `rules.ts`, so it tracks the real geometry rather than a literal.
- Checked against the build, not the dev server. Enter, exit from title, exit from paused, exit
  during play. Zero console errors.
- I captured exact frames by pinning `performance.now` to a constant and stubbing
  `requestAnimationFrame` to fire once with `t0 + X`. That paints one chosen frame of a timed
  animation through the real code path and leaves it on screen for a screenshot. Might be worth
  adding to `docs/verification.md`.

## Note on the handoff doc

`docs/superpowers/specs/2026-08-18-invaders-design.md` is updated locally with the new block table,
the third source and the reasoning, but `docs/superpowers/` is in the global gitignore so it is not
in this commit.
