### PR TITLE
feat: reach the game from the ⌘K palette

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -355,6 +355,15 @@ measures 4.45:1 against that wash.
 Empty offers RECENT posts and a JUMP TO chip row of the six pages. A miss is a real error line,
 `grep: kubernetes: no matches in 30 files`, then one muted line, then the three highest-count tags
 as chips. Every chip is an option, so the arrow keys reach it.
+`play` or `/play` puts one COMMANDS row at the top of the pane, above POSTS: the label `/play` in
+`--text-accent`, then `space invaders, in a terminal window`. It is the only row that runs something
+rather than going somewhere, so it is a button and not a link, and the footer reads `ENTER PLAY`
+while it is selected. It counts as a match, so a query no post answers reads `1 MATCH` and not
+`EXIT 1`. It exists only where the game does, above 900px on a fine pointer, and only under the
+`all` filter, because it is not a post, a tag or a page. The leading slash is optional because `/`
+opens the palette and the open clears the query, so that route into it types the word without one.
+The matcher is `matchCommand` in `src/lib/palette-commands.ts`; the row calls `launch` from
+`src/lib/invaders/index.ts`, the same starter the chrome dot uses.
 Keyboard: `⌘K`/`Ctrl+K` toggles, `/` opens when focus is outside a field, `↑` `↓` walk one flat
 list across the group rules and wrap, `Enter` opens, `Tab` cycles all → posts → tags → pages,
 `Backspace` on an empty query closes, `Esc` closes and returns focus to the trigger. Focus stays in

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -119,6 +119,10 @@ and never moves focus out of the dialog; `Backspace` on an empty query closes; `
 comes into view. Then check the states: `N MATCHES`, `30 INDEXED` empty, `EXIT 1` on a miss;
 selection is a wash plus a 2px left bar, never an inverted fill; 660px wide and 96px from the top
 above 640px, full screen below it with every row ≥44px; the footer is not clipped at 900px height.
+Then the `/play` row: above 900px, `play` and `/play` both offer it, the chrome reads `1 MATCH`
+rather than `EXIT 1`, `Enter` closes the palette and opens the game with the scroll lock handed over
+rather than dropped, and `Tab` off `all` takes it away. At 390px it does not exist and the query is
+an ordinary miss.
 `tests/e2e/palette.spec.ts` encodes all of this, including axe and the glyph audit over the open
 palette. `tests/unit/search.test.ts` covers ranking and caps, and `tests/unit/search-index.test.ts`
 guards the index shape and its size.

--- a/src/components/islands/CommandPalette.tsx
+++ b/src/components/islands/CommandPalette.tsx
@@ -11,6 +11,9 @@ import {
   type Result,
 } from '../../lib/search';
 import { TABS } from '../../lib/nav';
+import { matchCommand, type Command } from '../../lib/palette-commands';
+import { launch } from '../../lib/invaders';
+import { DESKTOP_QUERY } from '../../lib/invaders/rules';
 
 /**
  * The ⌘K palette: a search window over the dimmed page, keyboard first.
@@ -26,6 +29,12 @@ import { TABS } from '../../lib/nav';
 const INDEX_URL = '/search-index.json';
 const FILTERS: Filter[] = ['all', 'posts', 'tags', 'pages'];
 const OPTION_ID = 'palette-option';
+
+/**
+ * One flat list of everything the arrow keys walk. A result goes somewhere; a
+ * command runs something, so Enter has to tell them apart.
+ */
+type PaletteRow = { kind: 'result'; result: Result } | { kind: 'command'; command: Command };
 
 // Fetched on first open and kept for the life of the page: the index is
 // static, so a second fetch could only return the same bytes.
@@ -117,10 +126,12 @@ export default function CommandPalette() {
   const [query, setQuery] = useState('');
   const [filter, setFilter] = useState<Filter>('all');
   const [selected, setSelected] = useState(0);
+  const [supported, setSupported] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
+  const launchPending = useRef(false);
 
   const close = useCallback(() => {
     setOpen(false);
@@ -134,7 +145,16 @@ export default function CommandPalette() {
     () => (entries ? search(entries, query, filter) : []),
     [entries, query, filter]
   );
-  const matches = groups.reduce((sum, g) => sum + g.total, 0);
+  // Under `all` only: the command is not a post, a tag or a page, so it has no
+  // business surviving a filter that names one of those.
+  const command = useMemo(
+    () => (supported && filter === 'all' ? matchCommand(query) : null),
+    [supported, filter, query]
+  );
+
+  // The command counts, which is what keeps `grep: play: no matches` away from a
+  // screen that is offering the reader something.
+  const matches = groups.reduce((sum, g) => sum + g.total, 0) + (command ? 1 : 0);
   const noMatch = !isEmptyQuery && entries !== null && matches === 0;
 
   const recent = useMemo(() => (entries ? recentPosts(entries) : []), [entries]);
@@ -147,9 +167,11 @@ export default function CommandPalette() {
   // One flat list of destinations, in the order they are drawn. Arrow keys
   // cross group boundaries and reach the chips too, so every offer in the
   // palette is reachable without a mouse.
-  const rows: Result[] = useMemo(() => {
+  const rows: PaletteRow[] = useMemo(() => {
+    const asRows = (results: Result[]): PaletteRow[] =>
+      results.map((result) => ({ kind: 'result' as const, result }));
     if (isEmptyQuery) {
-      return [
+      return asRows([
         ...recent.map((entry) => ({ entry, matchedIn: 'title' as const, term: '' })),
         ...TABS.map((tab) => ({
           entry: {
@@ -162,13 +184,24 @@ export default function CommandPalette() {
           matchedIn: 'title' as const,
           term: '',
         })),
-      ];
+      ]);
     }
     if (noMatch) {
-      return tags.map((entry) => ({ entry, matchedIn: 'title' as const, term }));
+      return asRows(tags.map((entry) => ({ entry, matchedIn: 'title' as const, term })));
     }
-    return groups.flatMap((g) => g.results);
-  }, [isEmptyQuery, noMatch, recent, tags, groups, term]);
+    return [
+      ...(command ? [{ kind: 'command' as const, command }] : []),
+      ...asRows(groups.flatMap((g) => g.results)),
+    ];
+  }, [isEmptyQuery, noMatch, recent, tags, groups, term, command]);
+
+  // Closing first, launching second. Both windows lock the body scroll, and the
+  // effect below clears that lock on its way out: launching before it ran would
+  // leave the page scrolling behind the game.
+  const runCommand = useCallback(() => {
+    launchPending.current = true;
+    setOpen(false);
+  }, []);
 
   const move = useCallback(
     (step: number) => {
@@ -256,6 +289,26 @@ export default function CommandPalette() {
     };
   }, [open]);
 
+  // The game is gated at 900px on a fine pointer, so the command that opens it
+  // is gated with it. Read live rather than once, so a reader who resizes past
+  // the breakpoint gets the answer their device gives now.
+  useEffect(() => {
+    if (!open) return;
+    const media = window.matchMedia(DESKTOP_QUERY);
+    setSupported(media.matches);
+    const onChange = (event: MediaQueryListEvent) => setSupported(event.matches);
+    media.addEventListener('change', onChange);
+    return () => media.removeEventListener('change', onChange);
+  }, [open]);
+
+  // Runs after the effect above has cleaned up, which is the whole point: the
+  // scroll lock is released before the game takes it.
+  useEffect(() => {
+    if (open || !launchPending.current) return;
+    launchPending.current = false;
+    void launch();
+  }, [open]);
+
   useEffect(() => {
     if (!open || entries) return;
     loadIndex().then(setEntries, () => setFailed(true));
@@ -295,7 +348,8 @@ export default function CommandPalette() {
         const row = rows[selected];
         if (!row) break;
         event.preventDefault();
-        window.location.href = row.entry.url;
+        if (row.kind === 'command') runCommand();
+        else window.location.href = row.result.entry.url;
         break;
       }
       case 'Backspace':
@@ -457,12 +511,28 @@ export default function CommandPalette() {
             </div>
           )}
 
+          {!failed && command && (
+            <div role="group" aria-label="COMMANDS">
+              <Rule label="COMMANDS" meta={pad(1)} tight />
+              <CommandRow
+                command={command}
+                id={nextId()}
+                selected={index === selected}
+                onRun={runCommand}
+              />
+            </div>
+          )}
+
           {!failed &&
             !isEmptyQuery &&
             !noMatch &&
             groups.map((group, groupIndex) => (
               <div key={group.label} role="group" aria-label={group.label}>
-                <Rule label={group.label} meta={pad(group.total)} tight={groupIndex === 0} />
+                <Rule
+                  label={group.label}
+                  meta={pad(group.total)}
+                  tight={groupIndex === 0 && !command}
+                />
                 {group.results.map((result) => {
                   const id = nextId();
                   const isSelected = index === selected;
@@ -489,7 +559,8 @@ export default function CommandPalette() {
                 <span className="text-accent-lift">↑↓</span> MOVE
               </span>
               <span>
-                <span className="text-accent-lift">ENTER</span> OPEN
+                <span className="text-accent-lift">ENTER</span>{' '}
+                {rows[selected]?.kind === 'command' ? 'PLAY' : 'OPEN'}
               </span>
               <span>
                 <span className="text-accent-lift">TAB</span> FILTER
@@ -526,31 +597,42 @@ function Rule({ label, meta, tight }: { label: string; meta?: string; tight?: bo
  * The shared row frame. Selection is a wash plus a 2px left accent bar, never
  * the inverted fill the active tab uses: selection moves on every keypress and
  * a fill would strobe.
+ *
+ * A row with an `href` goes somewhere and is a link. A row with an `onClick`
+ * runs something and is a button. One class string covers both, so the two
+ * cannot drift apart.
  */
 function Row({
   href,
+  onClick,
   id,
   selected,
   children,
 }: {
-  href: string;
+  href?: string;
+  onClick?: () => void;
   id: string;
   selected: boolean;
   children: React.ReactNode;
 }) {
-  return (
-    <a
-      href={href}
-      id={id}
-      role="option"
-      aria-selected={selected}
-      data-palette-row
-      className={`block min-h-11 border-l-2 px-4 py-3 sm:px-4.5 sm:py-2.75 ${
-        selected ? 'border-accent bg-wash-code' : 'border-transparent'
-      }`}
-    >
+  const shared = {
+    id,
+    role: 'option',
+    'aria-selected': selected,
+    'data-palette-row': true,
+    className: `block w-full border-l-2 px-4 py-3 text-left min-h-11 sm:px-4.5 sm:py-2.75 ${
+      selected ? 'border-accent bg-wash-code' : 'border-transparent'
+    }`,
+  } as const;
+
+  return href ? (
+    <a href={href} {...shared}>
       {children}
     </a>
+  ) : (
+    <button type="button" onClick={onClick} {...shared}>
+      {children}
+    </button>
   );
 }
 
@@ -647,6 +729,35 @@ function PageRow({ result, id, selected }: { result: Result; id: string; selecte
         <span className={`mt-1.25 block text-xs sm:mt-0 sm:flex-1 ${metaInk(selected)}`}>
           <Highlight text={page.description} term={result.term} />
         </span>
+      </div>
+    </Row>
+  );
+}
+
+/** The one row that runs something instead of going somewhere. */
+function CommandRow({
+  command,
+  id,
+  selected,
+  onRun,
+}: {
+  command: Command;
+  id: string;
+  selected: boolean;
+  onRun: () => void;
+}) {
+  return (
+    <Row id={id} selected={selected} onClick={onRun}>
+      <div className="sm:flex sm:items-baseline sm:gap-3">
+        <span className="text-accent-lift">{command.label}</span>
+        <span className={`mt-1.25 block text-xs sm:mt-0 sm:flex-1 ${metaInk(selected)}`}>
+          {command.description}
+        </span>
+        {selected && (
+          <span className="hidden text-2xs tracking-chrome text-accent-lift sm:block sm:whitespace-nowrap">
+            PLAY
+          </span>
+        )}
       </div>
     </Row>
   );

--- a/src/lib/invaders/index.ts
+++ b/src/lib/invaders/index.ts
@@ -36,7 +36,8 @@ function modalOpen(): boolean {
   return document.querySelector('[role="dialog"][aria-modal="true"]') !== null;
 }
 
-async function launch(): Promise<void> {
+/** Starts the game. The palette's `/play` row calls this too. */
+export async function launch(): Promise<void> {
   try {
     const { openGame } = await import('./game');
     await openGame();

--- a/src/lib/palette-commands.ts
+++ b/src/lib/palette-commands.ts
@@ -1,0 +1,27 @@
+/**
+ * The palette's one command. Pure: the island
+ * (src/components/islands/CommandPalette.tsx) passes the typed query through
+ * here and draws whatever comes back.
+ *
+ * The leading slash is optional because `/` already opens the palette and the
+ * open resets the query, so a reader who arrives that way types `play` while a
+ * reader who arrives by ⌘K types `/play`. Both mean the same thing.
+ */
+
+export interface Command {
+  id: 'play';
+  /** What the row shows, slash included, whichever form the reader typed. */
+  label: string;
+  description: string;
+}
+
+const PLAY: Command = {
+  id: 'play',
+  label: '/play',
+  description: 'space invaders, in a terminal window',
+};
+
+export function matchCommand(query: string): Command | null {
+  const word = query.trim().toLowerCase().replace(/^\//, '');
+  return word === PLAY.id ? PLAY : null;
+}

--- a/tests/e2e/palette.spec.ts
+++ b/tests/e2e/palette.spec.ts
@@ -332,3 +332,75 @@ test.describe('reduced motion', () => {
     expect(parseFloat(style.duration)).toBeLessThan(0.01);
   });
 });
+
+test.describe('the /play command', () => {
+  // The game itself is gated at 900px on a fine pointer, so the row is too.
+  // The mobile project is 390px wide, which is the unsupported side of it.
+  const isSupported = (page: Page) => (page.viewportSize()?.width ?? 0) >= 900;
+  const commands = (page: Page) => page.locator('[role=group][aria-label=COMMANDS]');
+
+  test('offers the row for /play and for a bare play', async ({ page }) => {
+    test.skip(!isSupported(page), 'the game needs 900px and a fine pointer');
+    await open(page, '/play');
+    await expect(commands(page)).toContainText('/play');
+    await expect(commands(page)).toContainText('space invaders, in a terminal window');
+
+    // `/` opens the palette and the open clears the query, so a reader who
+    // arrives that way types the word without its slash.
+    await page.locator('[role=combobox]').fill('play');
+    await expect(commands(page)).toContainText('/play');
+  });
+
+  test('counts as a match rather than a miss', async ({ page }) => {
+    test.skip(!isSupported(page), 'the game needs 900px and a fine pointer');
+    await open(page, '/play');
+    const chrome = page.locator('[role=dialog] [aria-hidden=true]', { hasText: /INDEXED|MATCH|EXIT/ });
+    await expect(chrome).toHaveText('1 MATCH');
+    await expect(page.locator('[role=listbox]')).not.toContainText('no matches');
+  });
+
+  test('is the first row, and Enter on it opens the game', async ({ page }) => {
+    test.skip(!isSupported(page), 'the game needs 900px and a fine pointer');
+    await open(page, '/play');
+    await expect(page.locator('[role=option][aria-selected=true]')).toContainText('/play');
+
+    await page.keyboard.press('Enter');
+    await expect(page.locator('[role=dialog][aria-modal=true]')).toHaveCount(1);
+    const root = page.locator('[data-invaders-root]');
+    await expect(root).toBeVisible();
+    await expect(root).toHaveAttribute('data-armed', '');
+    // The palette is gone, and the game owns the scroll lock it left behind.
+    await expect(page.locator('[role=listbox]')).toHaveCount(0);
+    expect(await page.evaluate(() => document.body.style.overflow)).toBe('hidden');
+  });
+
+  // A guard, not a discovery: the row adds copy the audit above never sees,
+  // because that one opens the palette on a search query.
+  test('every glyph in the row comes from Departure Mono', async ({ page }) => {
+    test.skip(!isSupported(page), 'the game needs 900px and a fine pointer');
+    await open(page, '/play');
+    const fallbacks = await page.evaluate(() => {
+      const probe = (ch: string) => {
+        const s = document.createElement('span');
+        s.style.cssText = 'font:100px "Departure Mono";position:absolute;visibility:hidden';
+        s.textContent = ch;
+        document.body.append(s);
+        const w = s.getBoundingClientRect().width;
+        s.remove();
+        return w;
+      };
+      const M = probe('M');
+      const dialog = document.querySelector<HTMLElement>('[role=dialog]')!;
+      const used = [...new Set(dialog.innerText)].filter((c) => c.trim());
+      return used.filter((c) => Math.abs(probe(c) - M) > 0.5);
+    });
+    expect(fallbacks, `these fell back to a system font: ${fallbacks.join(' ')}`).toEqual([]);
+  });
+
+  test('does not exist below the gate', async ({ page }) => {
+    test.skip(isSupported(page), 'the row is real above 900px');
+    await open(page, '/play');
+    await expect(commands(page)).toHaveCount(0);
+    await expect(page.locator('[role=listbox]')).toContainText('no matches');
+  });
+});

--- a/tests/unit/palette-commands.test.ts
+++ b/tests/unit/palette-commands.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { matchCommand } from '../../src/lib/palette-commands';
+
+describe('matchCommand', () => {
+  it('matches the bare word', () => {
+    expect(matchCommand('play')?.id).toBe('play');
+  });
+
+  it('matches with the leading slash the palette never receives from `/`', () => {
+    expect(matchCommand('/play')?.id).toBe('play');
+  });
+
+  it('ignores case and surrounding space', () => {
+    expect(matchCommand('  /PLAY ')?.id).toBe('play');
+  });
+
+  it('carries the label and description the row draws', () => {
+    expect(matchCommand('play')).toMatchObject({
+      label: '/play',
+      description: 'space invaders, in a terminal window',
+    });
+  });
+
+  it('does not match a partial word', () => {
+    expect(matchCommand('/pla')).toBeNull();
+    expect(matchCommand('p')).toBeNull();
+  });
+
+  it('does not match a longer word that starts with it', () => {
+    expect(matchCommand('playwright')).toBeNull();
+  });
+
+  it('does not match a second slash', () => {
+    expect(matchCommand('//play')).toBeNull();
+  });
+
+  it('returns null for an empty query', () => {
+    expect(matchCommand('')).toBeNull();
+    expect(matchCommand('   ')).toBeNull();
+    expect(matchCommand('/')).toBeNull();
+  });
+});


### PR DESCRIPTION
The dot in the chrome was the only way into the game. Typing `play` or `/play`
in the ⌘K palette now offers it as well, above the POSTS rule, under a COMMANDS
rule of its own.

```
COMMANDS ─────────────────────────── 01
  /play        space invaders, in a terminal window
POSTS ────────────────────────────── 01
  2026-05-01   Playwright against a real browser
```

## What it does

**The slash is optional.** `/` already opens the palette and the open clears the
query, so a reader who arrives that way types the word without a slash, while a
reader who arrives by ⌘K types it with one. `matchCommand` drops one leading
slash before it compares, so both routes work and neither reader has to know
which one they took.

**The row counts as a match.** A query no post answers reads `1 MATCH` rather
than `EXIT 1`, which keeps `grep: play: no matches` off a screen that is
offering the reader something.

**It exists only where the game does**, above 900px on a fine pointer, read from
the same `DESKTOP_QUERY` in `src/lib/invaders/rules.ts` that the dot and the
`inv` sequence sit behind. The query is read on open and kept live with a
`matchMedia` listener, so a reader who resizes past the breakpoint gets the
answer their device gives now rather than a stale one. Below the gate the row
does not exist at all and the query falls through to ordinary search. It is also
gone under any filter other than `all`, because it is not a post, a tag or a
page.

**`ENTER PLAY` in the footer** while the row is selected, `PLAY` at the right of
the row itself. No new glyphs: selection is the same wash plus 2px accent bar
every other row uses.

## How it is built

`matchCommand` is a pure function in the new `src/lib/palette-commands.ts`, the
way `search.ts` is, and it carries the unit tests.

The row is the one thing in the palette that runs something rather than going
somewhere, so `Row` grows a button form beside its link form. Both forms share
one class string, so the two cannot drift apart. `Enter` and a click both reach
`launch`, now exported from `src/lib/invaders/index.ts` so there is a single
starter with a single piece of error handling.

The palette closes before the game opens. Both windows lock the body scroll and
the palette clears that lock on its way out, so the launch waits in an effect
keyed on `open`, after that cleanup has run. Launching any earlier leaves the
page scrolling behind the game. An e2e case asserts the lock is still held once
the game is armed, so a reordering fails in CI rather than shipping.

No new bytes on the wire. `lib/invaders` is already loaded on every page by
`BaseLayout`, and the built output keeps one copy of the launcher in a shared
`invaders.js` chunk that the palette now points at.

## Verification

- `npx vitest run`: 229 pass, 8 of them new for the matcher.
- `npx playwright test`: 362 pass, 0 fail. Five new cases in `palette.spec.ts`
  cover both spellings, the match count, the row order, the launch with its
  scroll lock, the glyphs in the row's copy, and its absence at 390px.
- `npx astro check`: 0 errors. `npm run build`: exit 0.
- Screenshots at 390, 768, 1024 and 1440. The row is there at 1024 and 1440 and
  absent at 390 and 768.

No post contains "play" yet, so the COMMANDS and POSTS pair above only happens
once one does. I forced it with a stubbed index to check the second rule keeps
its top gap, confirmed it, and dropped the throwaway spec.
